### PR TITLE
Update default PMD version to 6.21.0

### DIFF
--- a/messages/source_pmd.json
+++ b/messages/source_pmd.json
@@ -6,5 +6,5 @@
   "formatFlagDescription": "[default: text] The format for the pmd output, Possible values are available at https://pmd.github.io/latest/pmd_userdocs_cli_reference.html#available-report-formats",
   "reportFlagDescription": "[default: pmd-output] The path to where the output of the analysis should be written",
   "supressoutputFlagDescription": "[default: false] Supress the ouptut of the analysis to be displayed in the console",
-  "versionFlagDescription": "[default: 6.18.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory"
+  "versionFlagDescription": "[default: 6.21.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory"
 }

--- a/src/commands/sfpowerkit/source/pmd.ts
+++ b/src/commands/sfpowerkit/source/pmd.ts
@@ -59,7 +59,7 @@ export default class Pmd extends SfdxCommand {
     }),
     version: flags.string({
       required: false,
-      default: "6.18.0",
+      default: "6.21.0",
       description: messages.getMessage("versionFlagDescription")
     })
   };
@@ -87,7 +87,8 @@ export default class Pmd extends SfdxCommand {
       )
     ) {
       SFPowerkit.log("Initiating Download of  PMD", LoggerLevel.INFO);
-      fs.mkdirSync(pmd_cache_directory);
+      if (!fs.existsSync(pmd_cache_directory))
+        fs.mkdirSync(pmd_cache_directory);
       await this.downloadPMD(this.flags.version, pmd_cache_directory);
       SFPowerkit.log(`Downloaded PMD ${this.flags.version}`, LoggerLevel.INFO);
       await extract(
@@ -128,6 +129,7 @@ export default class Pmd extends SfdxCommand {
         )
       : this.flags.ruleset;
 
+    console.log(`PMD release ${this.flags.version}`);
     console.log(`Now analyzing ${packageDirectory}`);
 
     const pmdCmd = spawn(path.join(this.javahome, "bin", "java"), [


### PR DESCRIPTION
Solves issue #197 

- Check whether pmd_cache_directory already exists before creating directory. This
resolves the error that was preventing multiple PMD release versions from being
cached.

- Add console log that informs the user which PMD release version is running.