### PR TITLE
Fix Apex Test Suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,13 +234,10 @@ Converts an apex test suite to its consituent apex classes as a single line sepa
 
 ```
 USAGE
-  $ sfdx sfpowerkit:source:apextestsuite:convert  -n <string> [  -p <string> ] [  -o <string> ] [--json] [--loglevel trace|debug|info|warn|error|fatal]
+  $ sfdx sfpowerkit:source:apextestsuite:convert  -n <string> [--json] [--loglevel trace|debug|info|warn|error|fatal]
 
 OPTIONS
   -n, --name=name                                 (required) the name of the apextestsuite (the file name minus the apex test suite)
-  -p, --package=package                           [default:picks up the default package] The package where the apex test suite exists
-  -o, --pathoverride=pathoverride                 [default:/main/default] Use this if your path to test suite is in a different folder location
-                                                   within the package directory
 
   --json                                          format output as json
   --loglevel=(trace|debug|info|warn|error|fatal)  [default: warn] logging level for this command invocation

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -146,19 +146,16 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "dev": true
+      "version": "2.0.3"
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
-      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
@@ -431,6 +428,14 @@
         "tslib": "^1.10.0"
       },
       "dependencies": {
+        "@sinonjs/commons": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+          "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
         "@sinonjs/formatio": {
           "version": "2.0.0",
           "requires": {
@@ -469,10 +474,7 @@
               }
             },
             "lolex": {
-              "version": "5.1.2",
-              "requires": {
-                "@sinonjs/commons": "^1.7.0"
-              }
+              "version": "5.1.2"
             }
           }
         },
@@ -498,6 +500,7 @@
     },
     "@sinonjs/commons": {
       "version": "1.7.1",
+      "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -848,7 +851,6 @@
     },
     "braces": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -1535,7 +1537,6 @@
     },
     "fast-glob": {
       "version": "3.2.2",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1556,7 +1557,6 @@
     },
     "fastq": {
       "version": "1.6.1",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -1604,7 +1604,6 @@
     },
     "fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -1764,7 +1763,6 @@
     },
     "glob-parent": {
       "version": "5.1.0",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -2011,15 +2009,13 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0"
     },
     "is-glob": {
       "version": "4.0.1",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -2028,8 +2024,7 @@
       "version": "4.0.1"
     },
     "is-number": {
-      "version": "7.0.0",
-      "dev": true
+      "version": "7.0.0"
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -2416,12 +2411,10 @@
       "dev": true
     },
     "merge2": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
     },
     "micromatch": {
       "version": "4.0.2",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
@@ -3007,8 +3000,7 @@
       "version": "2.1.0"
     },
     "picomatch": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
     },
     "pify": {
       "version": "2.3.0"
@@ -3324,8 +3316,7 @@
       "dev": true
     },
     "reusify": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "rimraf": {
       "version": "3.0.2",
@@ -3335,8 +3326,7 @@
       }
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "dev": true
+      "version": "1.1.9"
     },
     "safe-buffer": {
       "version": "5.2.0"
@@ -3753,7 +3743,6 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,0 +1,2546 @@
+{
+  "version": "1.43.1-1",
+  "commands": {
+    "sfpowerkit:auth:login": {
+      "id": "sfpowerkit:auth:login",
+      "description": "Login to an org using a username/password",
+      "usage": "<%= command.id %> -u <string> -p <string> [-s <string>] [-r <url>] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:auth:login -u azlam@sfdc.com -p Xasdax2w2  -a prod\n      Authorized to azlam@sfdc.com\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "username": {
+          "name": "username",
+          "type": "option",
+          "char": "u",
+          "description": "Username for the org",
+          "required": true
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "char": "p",
+          "description": "Password for the org",
+          "required": true
+        },
+        "securitytoken": {
+          "name": "securitytoken",
+          "type": "option",
+          "char": "s",
+          "description": "Security Token for the org",
+          "required": false
+        },
+        "url": {
+          "name": "url",
+          "type": "option",
+          "char": "r",
+          "description": "URL of the instance to be authenticated, Defaults to Test URL",
+          "required": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "option",
+          "char": "a",
+          "description": "Alias ofthe org",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:destruct": {
+      "id": "sfpowerkit:org:destruct",
+      "description": "This is a helper command to ease the deployment of destructiveChanges.xml. The command will create the empty package.xml and package the passed destructive manifest and deploy it to the org",
+      "usage": "<%= command.id %> [-m <filepath>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:destruct -m destructiveChanges.xml -u prod@prod3.com"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "option",
+          "char": "m",
+          "description": "The path to xml containing the members that need to be destructed,follow the instructions here to create such a file https://developer.salesforce.com/docs/atlas.en-us.daas.meta/daas/daas_destructive_changes.htm",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:healthcheck": {
+      "id": "sfpowerkit:org:healthcheck",
+      "description": "Gets the health details of an org",
+      "usage": "<%= command.id %> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:healthcheck  -u myOrg@example.com\n  Successfully Retrived the healthstatus of the org\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:orgcoverage": {
+      "id": "sfpowerkit:org:orgcoverage",
+      "description": "Gets the apex test coverage details of an org",
+      "usage": "<%= command.id %> [-d <string>] [-f json|csv] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$  sfdx sfpowerkit:org:orgcoverage  -u myOrg@example.com\n  sfdx sfpowerkit:org:orgcoverage  -u myOrg@example.com -d testResult -f csv\n  sfdx sfpowerkit:org:orgcoverage  -u myOrg@example.com -d testResult -f json\n\n\n  Successfully Retrieved the Apex Test Coverage of the org XXXX\n  coverage:85\n  ID     \t\tNAME                  TYPE          PERCENTAGE    COMMENTS                              UNCOVERED LINES\n  ───────\t\t──────────────────    ────────      ──────────\t  ───────────────────────────────────   ──────────────────\n  01pxxxx\t\tsampleController      ApexClass     100%\n  01pxxxx\t\tsampletriggerHandler  ApexClass\t    80%           Looks fine but target more than 85%   62;76;77;\n  01pxxxx\t\tsampleHelper          ApexClass\t    72%           Action required                       62;76;77;78;98;130;131\n  01qxxxx\t\tsampleTrigger         ApexTrigger   100%\n  Output testResult/output.csv is generated successfully\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "d",
+          "description": " The output dir where the output will be created",
+          "required": false
+        },
+        "format": {
+          "name": "format",
+          "type": "option",
+          "char": "f",
+          "description": " The format for the test result output, Possible values are json/csv",
+          "required": false,
+          "helpValue": "(json|csv)",
+          "options": ["json", "csv"]
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:applypatch": {
+      "id": "sfpowerkit:package:applypatch",
+      "description": "Retrieves and applies the patch, Useful after a package upgrade in a CD Environment",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:applypatch -n customer_picklist -u sandbox\n    Preparing Patch\n    Deploying Patch with ID  0Af4Y000003Q7GySAK\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Patch customer_picklist Deployed successfully.\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the static resource to be patched",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:valid": {
+      "id": "sfpowerkit:package:valid",
+      "description": "Validates a package to check whether it only contains valid metadata as per metadata coverage",
+      "usage": "<%= command.id %> [-n <string>] [-b <array>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:valid -n testPackage\n  Now analyzing testPackage\nConverting package testPackage\nElements supported included in your package testPackage are\n[\n  \"AuraDefinitionBundle\",\n  \"CustomApplication\",\n  \"ApexClass\",\n  \"ContentAsset\",\n  \"WorkflowRule\"\n]\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "n",
+          "description": "the package to analyze",
+          "required": false
+        },
+        "bypass": {
+          "name": "bypass",
+          "type": "option",
+          "char": "b",
+          "description": "metadatatypes to skip the package validation check",
+          "required": false
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "metadata API version to use for validation"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:project:diff": {
+      "id": "sfpowerkit:project:diff",
+      "description": "Generate a delta 'changeset' between two diff commits so that  the incremental changes can be deployed to the target org.To be used for an org based deployment and the size of the metadata is large that the project cannot not be deployed in a single attempt./nThis command works with a source format based repository only. Utilize the command during a transition phase where an org is transformed to a modular architecture composing of multiple projects.",
+      "usage": "<%= command.id %> -r <string> -d <string> [-t <string>] [-x] [-b <array>] [-p <array>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:project:diff --diffFile DiffFileName --encoding EncodingOfFile --output OutputFolder",
+        "$ sfdx sfpowerkit:project:diff --revisionfrom revisionfrom --revisionto revisionto --output OutputFolder\n   "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "revisionfrom": {
+          "name": "revisionfrom",
+          "type": "option",
+          "char": "r",
+          "description": "Base revision from where diff is to be generated, required if diff file is ommited",
+          "required": true
+        },
+        "revisionto": {
+          "name": "revisionto",
+          "type": "option",
+          "char": "t",
+          "description": " [default:HEAD] Target revision to generate the diff ",
+          "required": false
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "d",
+          "description": " The output dir where the incremental project will be created",
+          "required": true
+        },
+        "generatedestructive": {
+          "name": "generatedestructive",
+          "type": "boolean",
+          "char": "x",
+          "description": "If set to true, the command will also generate a destructiveChangePost.xml file in the output folder.",
+          "required": false,
+          "allowNo": false
+        },
+        "bypass": {
+          "name": "bypass",
+          "type": "option",
+          "char": "b",
+          "description": "[EXPERIMENTAL] Ignore comma seperated paths from the diff being generated, the  diff command doesnt generate a diff on the following paths",
+          "required": false
+        },
+        "packagedirectories": {
+          "name": "packagedirectories",
+          "type": "option",
+          "char": "p",
+          "description": "[EXPERIMENTAL] Run diff only on specific paths, also generate a sfdx-project.json to support the corresponding package directory",
+          "required": false
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:project:orgdiff": {
+      "id": "sfpowerkit:project:orgdiff",
+      "description": "Compare source file again the salesforce and display differences. Can optionally add diff conflict markers on file to let the developer accept or rejest changes manually using a git merge tool.",
+      "usage": "<%= command.id %> -f <array> [-c] [-o json|csv] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:project:orgdiff --folder directory --noconflictmarkers --targetusername sandbox",
+        "$ sfdx sfpowerkit:project:orgdiff  --filename fileName --targetusername sandbox"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "filesorfolders": {
+          "name": "filesorfolders",
+          "type": "option",
+          "char": "f",
+          "description": "List of fils or folder to compare. Should be only Apex classes, trigger, Aura Components, Lightning Web Components or any unsplitted metadata.",
+          "required": true
+        },
+        "noconflictmarkers": {
+          "name": "noconflictmarkers",
+          "type": "boolean",
+          "char": "c",
+          "description": "If set to true, the command will not add diff conflict marker to each compared file.",
+          "required": false,
+          "allowNo": false
+        },
+        "outputformat": {
+          "name": "outputformat",
+          "type": "option",
+          "char": "o",
+          "description": " [default: json]The format for the diff output, Possible values are json/csv.",
+          "required": false,
+          "helpValue": "(json|csv)",
+          "options": ["json", "csv"]
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:pmd": {
+      "id": "sfpowerkit:source:pmd",
+      "description": "This command is a wrapper around PMD ( downloads PMD for the first time) with some predefined defaults, such as ruleset, output format, output file. The command is to be run from the project directory",
+      "usage": "<%= command.id %> [-d <string>] [-r <string>] [-f <string>] [-o <string>] [--javahome <string>] [--supressoutput] [--version <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": ["$ sfdx sfpowerkit:source:pmd"],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "directory": {
+          "name": "directory",
+          "type": "option",
+          "char": "d",
+          "description": "[default: Default project directory as mentioned in sfdx-project.json] Override this to set a different directory in the project folder",
+          "required": false
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "option",
+          "char": "r",
+          "description": "[default: sfpowerkit] The pmd ruleset that will be utilzied for analyzing the apex classes,  Checkout https://pmd.github.io/latest/pmd_userdocs_making_rulesets.html to create your own ruleset",
+          "required": false
+        },
+        "format": {
+          "name": "format",
+          "type": "option",
+          "char": "f",
+          "description": "[default: text] The format for the pmd output, Possible values are available at https://pmd.github.io/latest/pmd_userdocs_cli_reference.html#available-report-formats",
+          "required": false,
+          "default": "text"
+        },
+        "report": {
+          "name": "report",
+          "type": "option",
+          "char": "o",
+          "description": "[default: pmd-output] The path to where the output of the analysis should be written",
+          "required": false,
+          "default": "pmd-output"
+        },
+        "javahome": {
+          "name": "javahome",
+          "type": "option",
+          "description": "The command will try to locate the javahome path to execute PMD automatically, set this flag to override it to another javahome path",
+          "required": false
+        },
+        "supressoutput": {
+          "name": "supressoutput",
+          "type": "boolean",
+          "description": "[default: false] Supress the ouptut of the analysis to be displayed in the console",
+          "required": false,
+          "allowNo": false
+        },
+        "version": {
+          "name": "version",
+          "type": "option",
+          "description": "[default: 6.21.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory",
+          "required": false,
+          "default": "6.21.0"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:connectedapp:create": {
+      "id": "sfpowerkit:org:connectedapp:create",
+      "description": " Creates a connected app in the target org for JWT based authentication, Please note it only creates Connected App with All users may self authorize option, You would need to manually edit the policies to enable admin users are pre-approved and add your profile to this connected app",
+      "usage": "<%= command.id %> -n <string> -c <filepath> -e <email> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:connectedapp:create -u myOrg@example.com -n AzurePipelines -c id_rsa -e azlam.salamm@invalid.com\n  Created Connected App AzurePipelines in Target Org\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the connected app to be created",
+          "required": true
+        },
+        "pathtocertificate": {
+          "name": "pathtocertificate",
+          "type": "option",
+          "char": "c",
+          "description": "Filepath to the private certificate for the connected app to be created",
+          "required": true
+        },
+        "email": {
+          "name": "email",
+          "type": "option",
+          "char": "e",
+          "description": "Email of the connected app to be created",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:connectedapp:retrieve": {
+      "id": "sfpowerkit:org:connectedapp:retrieve",
+      "description": "Retrieves the consumer key for a connected app, Useful after a sandbox refresh in a CD Environment",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:connectedapp:retrieve -n AzurePipelines -u azlam@sfdc.com \n  Retrived AzurePipelines Consumer Key : XSD21Sd23123w21321\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the connected app to be retreived",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:duplicaterule:activate": {
+      "id": "sfpowerkit:org:duplicaterule:activate",
+      "description": "Activates a duplicate rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:duplicaterule:Activate -n Account.CRM_Account_Rule_1 -u sandbox\n    Polling for Retrieval Status\n    Retrieved Duplicate Rule  with label : CRM Account Rule 2\n    Preparing Activation\n    Deploying Activated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Duplicate Rule CRM Account Rule 2 Activated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the duplicate rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:duplicaterule:deactivate": {
+      "id": "sfpowerkit:org:duplicaterule:deactivate",
+      "description": "Deactivates a duplicate rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:duplicaterule:deactivate -n Account.CRM_Account_Rule_1 -u sandbox\n    Polling for Retrieval Status\n    Retrieved Duplicate Rule  with label : CRM Account Rule 2\n    Preparing Deactivation\n    Deploying Deactivated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Duplicate Rule CRM Account Rule 2 deactivated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the duplicate rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:manifest:build": {
+      "id": "sfpowerkit:org:manifest:build",
+      "description": "Generate a complete manifest of all the metadata from the specified org. Once the manifest is generated use source:retrieve or mdapi:retrieve to retrieve the metadata.",
+      "usage": "<%= command.id %> [-q <string>] [-x] [-o <filepath>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml\n    <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n    <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">...</Package>\n    ",
+        "$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -q 'ApexClass, CustomObject, Report' \n    <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n    <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">...</Package>\n    "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "quickfilter": {
+          "name": "quickfilter",
+          "type": "option",
+          "char": "q",
+          "description": "comma separated values  of metadata type, member or file names to be excluded while building the manifest"
+        },
+        "excludemanaged": {
+          "name": "excludemanaged",
+          "type": "boolean",
+          "char": "x",
+          "description": "exclude managed packages components from the manifest",
+          "allowNo": false
+        },
+        "outputfile": {
+          "name": "outputfile",
+          "type": "option",
+          "char": "o",
+          "description": "The output path where the manifest file will be created"
+        }
+      },
+      "args": [{ "name": "file" }]
+    },
+    "sfpowerkit:org:matchingrule:activate": {
+      "id": "sfpowerkit:org:matchingrule:activate",
+      "description": "Activates a matching rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:matchingrules:activate -n Account -u sandbox\n    Polling for Retrieval Status\n    Retrieved Matching Rule  for Object : Account\n    Preparing Activation\n    Deploying Activated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Matching Rule for  Account activated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the object that has the matching rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:matchingrule:deactivate": {
+      "id": "sfpowerkit:org:matchingrule:deactivate",
+      "description": "Deactivates a matching rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:matchingrules:deactivate -n Account -u sandbox\n    Polling for Retrieval Status\n    Retrieved Matching Rule  for Object : Account\n    Preparing Deactivation\n    Deploying Deactivated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Matching Rule for  Account deactivated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the object that has the matching rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:orgwideemail:create": {
+      "id": "sfpowerkit:org:orgwideemail:create",
+      "description": "This command is deprecated, Please update your workflows..Create an orgWide Email Address",
+      "usage": "<%= command.id %> -e <email> -n <string> [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "sfdx sfpowerkit:org:orgwideemail:create -e testuser@test.com  -u scratch1 -n \"Test Address\" -p\n     Creating email azlam.abdulsalam@accenture.com\n     Org wide email created with Id 0D2210000004DidCAE\n     Run the folowing command to verify it\n    sfdx sfpowerkit:org:orgwideemail:verify -i 0D2210000004DidCAE -u test-jkomdylblorj@example.com  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "address": {
+          "name": "address",
+          "type": "option",
+          "char": "e",
+          "description": "Org Wide address email",
+          "required": true
+        },
+        "displayname": {
+          "name": "displayname",
+          "type": "option",
+          "char": "n",
+          "description": "Org Wide address display name",
+          "required": true
+        },
+        "allprofile": {
+          "name": "allprofile",
+          "type": "boolean",
+          "char": "p",
+          "description": "Allow for all profile",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:orgwideemail:verify": {
+      "id": "sfpowerkit:org:orgwideemail:verify",
+      "description": "This command is deprecated, Please update your workflows..Verify an already created orgWide Email Address",
+      "usage": "<%= command.id %> -i <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:orgwideemail:verify --username scratchOrg --emailid orgwideemailid\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "emailid": {
+          "name": "emailid",
+          "type": "option",
+          "char": "i",
+          "description": "Id of the Org Wide address email to verify",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:sandbox:create": {
+      "id": "sfpowerkit:org:sandbox:create",
+      "description": "Creates a sandbox using the tooling api, ensure the user has the required permissions before using this command",
+      "usage": "<%= command.id %> -n <string> -d <string> -l <string> [-a <string>] [-f <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:sandbox:create -d Testsandbox -l DEVELOPER -n test2 -u myOrg@example.com\n  Successfully Enqueued Creation of Sandbox\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the sandbox",
+          "required": true
+        },
+        "description": {
+          "name": "description",
+          "type": "option",
+          "char": "d",
+          "description": "Description of the sandbox",
+          "required": true
+        },
+        "licensetype": {
+          "name": "licensetype",
+          "type": "option",
+          "char": "l",
+          "description": "Type of the sandbox. Valid values are  DEVELOPER,DEVELOPER_PRO,PARTIAL,FULL",
+          "required": true,
+          "options": ["DEVELOPER", "DEVELOPER_PRO", "PARTIAL", "FULL"]
+        },
+        "apexclass": {
+          "name": "apexclass",
+          "type": "option",
+          "char": "a",
+          "description": "A reference to the ID of an Apex class that runs after each copy of the sandbox",
+          "required": false,
+          "default": ""
+        },
+        "clonefrom": {
+          "name": "clonefrom",
+          "type": "option",
+          "char": "f",
+          "description": "A reference to the ID of a SandboxInfo that serves as the source org for a cloned sandbox.",
+          "required": false,
+          "default": ""
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:sandbox:info": {
+      "id": "sfpowerkit:org:sandbox:info",
+      "description": "Gets the status of a sandbox",
+      "usage": "<%= command.id %> -n <string> [-s] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:sandbox:info -n test2  -v produser@example.com \n  Successfully Enqueued Refresh of Sandbox\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the sandbox",
+          "required": true
+        },
+        "showonlylatest": {
+          "name": "showonlylatest",
+          "type": "boolean",
+          "char": "s",
+          "description": "Shows only the latest info of the sandbox record",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:sandbox:refresh": {
+      "id": "sfpowerkit:org:sandbox:refresh",
+      "description": "Refresh a sandbox using the tooling api, ensure the user has the required permissions before using this command",
+      "usage": "<%= command.id %> -n <string> [-f <string>] [-l <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:sandbox:refresh -n test2  -f sitSandbox -v myOrg@example.com\n  Successfully Enqueued Refresh of Sandbox\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the sandbox",
+          "required": true
+        },
+        "clonefrom": {
+          "name": "clonefrom",
+          "type": "option",
+          "char": "f",
+          "description": "Name of the SandboxInfo that serves as the source org for a cloned sandbox.",
+          "required": false,
+          "default": ""
+        },
+        "licensetype": {
+          "name": "licensetype",
+          "type": "option",
+          "char": "l",
+          "description": "Type of the sandbox. Valid values are  DEVELOPER,DEVELOPER_PRO,PARTIAL,FULL, Provide this if the sandbox is to be rereshed from Production",
+          "required": false,
+          "options": ["DEVELOPER", "DEVELOPER_PRO", "PARTIAL", "FULL"]
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:scratchorg:delete": {
+      "id": "sfpowerkit:org:scratchorg:delete",
+      "description": "Gets the active count of scratch org by users in a devhub",
+      "usage": "<%= command.id %> -e <string> [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:scratchorg:delete  -e xyz@kyz.com -v devhub\n    Found Scratch Org Ids for user xyz@kyz.com\n    2AS6F000000XbxVWAS\n    Deleting Scratch Orgs\n    Deleted Scratch Org 2AS6F000000XbxVWAS\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "email": {
+          "name": "email",
+          "type": "option",
+          "char": "e",
+          "description": "Email of the user account that has created the scratch org",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:scratchorg:usage": {
+      "id": "sfpowerkit:org:scratchorg:usage",
+      "description": "Gets the active count of scratch org by users in a devhub",
+      "usage": "<%= command.id %> [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:scratchorg:usage -v devhub\n    Active Scratch Orgs Remaining: 42 out of 100\n    Daily Scratch Orgs Remaining: 171 out of 200\n\n    SCRATCH_ORGS_USED  NAME\n    ─────────────────  ─────────────────\n    2                  XYZ@KYZ.COM\n    2                  JFK@KYZ.COM\n    Total number of records retrieved: 4.\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:trigger:activate": {
+      "id": "sfpowerkit:org:trigger:activate",
+      "description": "Activates a trigger in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:trigger:activate -n AccountTrigger -u sandbox\n    Polling for Retrieval Status\n    Preparing Activation\n    Deploying Activated ApexTrigger with ID  0Af4Y000003Q7GySAK\n    Polling for Deployment Status\n    Polling for Deployment Status\n    ApexTrigger AccountTrigger Activated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the trigger that has to be activated",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:trigger:deactivate": {
+      "id": "sfpowerkit:org:trigger:deactivate",
+      "description": "Deactivates a trigger in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:trigger:deactivate -n AccountTrigger -u sandbox\n    Polling for Retrieval Status\n    Preparing Deactivation\n    Deploying Deactivated ApexTrigger with ID  0Af4Y000003Q7GySAK\n    Polling for Deployment Status\n    Polling for Deployment Status\n    ApexTrigger AccountTrigger deactivated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the trigger that has to be deactivated",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:dependencies:install": {
+      "id": "sfpowerkit:package:dependencies:install",
+      "description": "Install dependencies of a package",
+      "usage": "<%= command.id %> [-p <string>] [-k <string>] [-b <string>] [-w <string>] [-r] [-o] [-a] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfpowerkit package:dependencies:install -u MyScratchOrg -v MyDevHub -k \"1:MyPackage1Key 2: 3:MyPackage3Key\" -b \"DEV\""
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "individualpackage": {
+          "name": "individualpackage",
+          "type": "option",
+          "char": "p",
+          "description": "Installs a specific package especially for upgrade scenario",
+          "required": false
+        },
+        "installationkeys": {
+          "name": "installationkeys",
+          "type": "option",
+          "char": "k",
+          "description": "installation key for key-protected packages (format is 1:MyPackage1Key 2: 3:MyPackage3Key... to allow some packages without installation key)",
+          "required": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "option",
+          "char": "b",
+          "description": "the package version’s branch",
+          "required": false
+        },
+        "wait": {
+          "name": "wait",
+          "type": "option",
+          "char": "w",
+          "description": "number of minutes to wait for installation status (also used for publishwait). Default is 10",
+          "required": false
+        },
+        "noprompt": {
+          "name": "noprompt",
+          "type": "boolean",
+          "char": "r",
+          "description": "allow Remote Site Settings and Content Security Policy websites to send or receive data without confirmation",
+          "required": false,
+          "allowNo": false
+        },
+        "updateall": {
+          "name": "updateall",
+          "type": "boolean",
+          "char": "o",
+          "description": "Update all packages even if they are installed in the target org",
+          "required": false,
+          "allowNo": false
+        },
+        "apexcompileonlypackage": {
+          "name": "apexcompileonlypackage",
+          "type": "boolean",
+          "char": "a",
+          "description": "Compile the apex only in the package, by default only the compilation of the apex in the entire org is triggered",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:version:codecoverage": {
+      "id": "sfpowerkit:package:version:codecoverage",
+      "description": "This command is used to get the apex test coverage details of an unlocked package",
+      "usage": "<%= command.id %> [-p <string>] [-n <string>] [-i <array>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:version:codecoverage -u myOrg@example.com -i 04tXXXXXXXXXXXXXXX \n$ sfdx sfpowerkit:package:version:codecoverage -u myOrg@example.com -i 04tXXXXXXXXXXXXXXX,04tXXXXXXXXXXXXXXX,04tXXXXXXXXXXXXXXX \n$ sfdx sfpowerkit:package:version:codecoverage -u myOrg@example.com -p core -n 1.2.0.45 \n$ sfdx sfpowerkit:package:version:codecoverage -u myOrg@example.com -p 0HoXXXXXXXXXXXXXXX -n 1.2.0.45"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "API version"
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "p",
+          "description": "Name of the unlocked package to check the code coverage, packageVersionNumber is required when packageName is used",
+          "required": false
+        },
+        "versionnumber": {
+          "name": "versionnumber",
+          "type": "option",
+          "char": "n",
+          "description": "The complete version number format is major.minor.patch (Beta build)—for example, 1.2.0 (Beta 5), packageName is required when packageVersionNumber is used",
+          "required": false
+        },
+        "versionid": {
+          "name": "versionid",
+          "type": "option",
+          "char": "i",
+          "description": "Package version Id to check the code coverage",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:version:info": {
+      "id": "sfpowerkit:package:version:info",
+      "description": "This command is list all the installed (managed/unmanaged) packages in an org",
+      "usage": "<%= command.id %> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:version:info -u myOrg@example.com "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "API version"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:apextestsuite:convert": {
+      "id": "sfpowerkit:source:apextestsuite:convert",
+      "description": "Converts an apex test suite to its consituent apex classes as a single line separated by commas, so that it can be used for metadata api deployment",
+      "usage": "<%= command.id %> -n <string> [-p <string>] [-o <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:apextestsuite:convert -n MyApexTestSuite \n    \"ABC2,ABC1Test\"    \n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "The name of the apextestsuite (the file name minus the apex test suite)",
+          "required": true
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "p",
+          "description": "The package where the apex test suite exists",
+          "required": false
+        },
+        "pathoverride": {
+          "name": "pathoverride",
+          "type": "option",
+          "char": "o",
+          "description": "The path to be overriden in case test suite are in a different folder in the target package",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:customlabel:create": {
+      "id": "sfpowerkit:source:customlabel:create",
+      "description": "Custom Labels are org wide, hence when the metadata is pulled down from scratch org, the entire custom label metadata file is updated in a package repo. This command is a helper command to create customlabel with pacakage names prepended for easy reconcilation.",
+      "usage": "<%= command.id %> -n <string> -v <string> -s <string> [-c <string>] [-l <string>] [-p <string>] [--package <string>] [-i] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:customlabel:create -u fancyScratchOrg1 -n FlashError -v \"Memory leaks aren't for the faint hearted\" -s \"A flashing error --package core\"\n  Deployed CustomLabel FlashError in target org with core_  prefix, You may now pull and utilize the customlabel:reconcile command\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "fullname": {
+          "name": "fullname",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the custom label (API Name)",
+          "required": true
+        },
+        "value": {
+          "name": "value",
+          "type": "option",
+          "char": "v",
+          "description": "Value of the custom label",
+          "required": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "option",
+          "char": "c",
+          "description": "Comma Separated Category Values",
+          "required": false
+        },
+        "language": {
+          "name": "language",
+          "type": "option",
+          "char": "l",
+          "description": "Language of the custom label (Default: en_US)",
+          "required": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "option",
+          "char": "p",
+          "description": "Protected State of the custom label (Default: false)",
+          "required": false
+        },
+        "shortdescription": {
+          "name": "shortdescription",
+          "type": "option",
+          "char": "s",
+          "description": "Short Description of the custom label",
+          "required": true
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "description": "The name of the package that needs to be appended",
+          "required": false
+        },
+        "ignorepackage": {
+          "name": "ignorepackage",
+          "type": "boolean",
+          "char": "i",
+          "description": "Ignores the addition of the package into the fullname (API Name)",
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:customlabel:reconcile": {
+      "id": "sfpowerkit:source:customlabel:reconcile",
+      "description": "Custom Labels are org wide, hence when the metadata is pulled down from scratch org, the entire custom label metadata file is updated in a package repo, This command reconcile the updated custom labels to include only the labels that have the API name starting with package name or created using the custom label create command",
+      "usage": "<%= command.id %> -d <string> -p <string> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:customlabel:reconcile -d path/to/customlabelfile.xml -p core\n    Cleaned The Custom Labels\n"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "char": "d",
+          "description": "Path to the CustomLabels.labels-meta.xml file",
+          "required": true
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "char": "p",
+          "description": "The name of the package that needs to be reconciled",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:permissionset:generatepatch": {
+      "id": "sfpowerkit:source:permissionset:generatepatch",
+      "description": "Search permissionsets inside project and create a static resource file with permissionsets, used to solve the recordtype assignment upgrade issue in dx unlock package",
+      "usage": "<%= command.id %> [-p <string>] [-d <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:permissionset:generatepatch -p Core -d src/core/main/default/permissionsets"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "p",
+          "description": "Name of the package to generate the permissionset patch",
+          "required": false
+        },
+        "permsetdir": {
+          "name": "permsetdir",
+          "type": "option",
+          "char": "d",
+          "description": "Path for permissionset folder located in project",
+          "required": false
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "The api version to be used for the static resource to be generated"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:picklist:generatepatch": {
+      "id": "sfpowerkit:source:picklist:generatepatch",
+      "description": "Search picklist fields inside project and create a static resource file with picklist fields, used to solve the picklist upgrade issue in dx unlock package",
+      "usage": "<%= command.id %> [-p <string>] [-d <string>] [-f] [-r] [-m] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:picklist:generatepatch -p sfpowerkit_test -d force-app/main/default/objects/ -f"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "p",
+          "description": "Name of the package to generate the picklist patch",
+          "required": false
+        },
+        "objectsdir": {
+          "name": "objectsdir",
+          "type": "option",
+          "char": "d",
+          "description": "Path for Objects folder located in project",
+          "required": false
+        },
+        "fixstandardvalueset": {
+          "name": "fixstandardvalueset",
+          "type": "boolean",
+          "char": "f",
+          "description": "Consider patching for standard value set controlled picklists, Warning: This modifies the source code in your package",
+          "required": false,
+          "allowNo": false
+        },
+        "fixrecordtypes": {
+          "name": "fixrecordtypes",
+          "type": "boolean",
+          "char": "r",
+          "description": "Consider patching for standard value set in RecordTypes, Warning: This modifies the source code in your package",
+          "required": false,
+          "allowNo": false
+        },
+        "movestandardvalueset": {
+          "name": "movestandardvalueset",
+          "type": "boolean",
+          "char": "m",
+          "description": "Consider patching for standard valueset inside source repo, Warning: This modifies the source code in your package",
+          "required": false,
+          "allowNo": false
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "The api version to be used for the static resource to be generated"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:profile:merge": {
+      "id": "sfpowerkit:source:profile:merge",
+      "description": "This command is used in the lower environments such as ScratchOrgs , Development / System Testing Sandboxes, inorder to apply the changes made in the environment to retrieved profile, so that it can be deployed to the higher environments",
+      "usage": "<%= command.id %> [-f <array>] [-n <array>] [-m <array>] [-d] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:profile:merge -u sandbox",
+        "$ sfdx sfpowerkit:source:profile:merge -f force-app -n \"My Profile\" -r -u sandbox",
+        "$ sfdx sfpowerkit:source:profile:merge -f \"module1, module2, module3\" -n \"My Profile1, My profile2\"  -u sandbox"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "option",
+          "char": "f",
+          "description": "comma separated list of folders to scan for profiles. If ommited, the folders in the packageDirectories configuration will be used.",
+          "required": false
+        },
+        "profilelist": {
+          "name": "profilelist",
+          "type": "option",
+          "char": "n",
+          "description": "comma separated list of profiles. If ommited, all the profiles found in the folder(s) will be merged",
+          "required": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "option",
+          "char": "m",
+          "description": "comma separated list of metadata for which the permissions will be retrieved.",
+          "required": false
+        },
+        "delete": {
+          "name": "delete",
+          "type": "boolean",
+          "char": "d",
+          "description": "set this flag to delete profile files that does not exist in the org.",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:profile:reconcile": {
+      "id": "sfpowerkit:source:profile:reconcile",
+      "description": "This command is used in the lower environments such as ScratchOrgs , Development / System Testing Sandboxes, where a retrieved profile from production has to be cleaned up only for the metadata that is contained in the environment or  base it only as per the metadata that is contained in the packaging directory.",
+      "usage": "<%= command.id %> [-f <array>] [-n <array>] [-d <directory>] [-s] [-u <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:profile:reconcile  --folder force-app -d destfolder -s",
+        "$ sfdx sfpowerkit:source:profile:reconcile  --folder force-app,module2,module3 -u sandbox -d destfolder",
+        "$ sfdx sfpowerkit:source:profile:reconcile  -u myscratchorg -d destfolder"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "option",
+          "char": "f",
+          "description": "path to the folder which contains the profiles to be reconciled,if project contain multiple package directories, please provide a comma seperated list, if omitted, all the package directories will be checked for profiles",
+          "required": false
+        },
+        "profilelist": {
+          "name": "profilelist",
+          "type": "option",
+          "char": "n",
+          "description": "list of profiles to be reconciled. If ommited, all the profiles components will be reconciled.",
+          "required": false
+        },
+        "destfolder": {
+          "name": "destfolder",
+          "type": "option",
+          "char": "d",
+          "description": " the destination folder for reconciled profiles, if omitted existing profiles will be reconciled and will be rewritten in the current location",
+          "required": false
+        },
+        "sourceonly": {
+          "name": "sourceonly",
+          "type": "boolean",
+          "char": "s",
+          "description": "set this flag to reconcile profiles only against component available in the project only. Configure ignored perissions in sfdx-project.json file in the array plugins->sfpowerkit->ignoredPermissions.",
+          "required": false,
+          "allowNo": false
+        },
+        "targetorg": {
+          "name": "targetorg",
+          "type": "option",
+          "char": "u",
+          "description": " org against which profiles will be reconciled. this parameter can be ommited if sourceonly flag is set.",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:profile:retrieve": {
+      "id": "sfpowerkit:source:profile:retrieve",
+      "description": "Retrieve profiles from the salesforce org with all its associated permissions. Common use case for this command is  to migrate profile changes from a integration environment to other higher environments [overcomes SFDX CLI Profile retrieve issue where it doesnt fetch the full profile unless the entire metadata is present in source], or retrieving profiles from production to lower environments for testing.",
+      "usage": "<%= command.id %> [-f <array>] [-n <array>] [-d] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:profile:retrieve -u prod",
+        "$ sfdx sfpowerkit:source:profile:retrieve  -f force-app -n \"My Profile\" -u prod",
+        "$ sfdx sfpowerkit:source:profile:retrieve  -f \"module1, module2, module3\" -n \"My Profile1, My profile2\"  -u prod"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "option",
+          "char": "f",
+          "description": "retrieve only updated versions of profiles found in this directory, If ignored, all profiles will be retrieved.",
+          "required": false
+        },
+        "profilelist": {
+          "name": "profilelist",
+          "type": "option",
+          "char": "n",
+          "description": "comma separated list of profiles to be retrieved. Use it for selectively retrieving an existing profile or retrieving a new profile",
+          "required": false
+        },
+        "delete": {
+          "name": "delete",
+          "type": "boolean",
+          "char": "d",
+          "description": "set this flag to delete profile files that does not exist in the org, when retrieving in bulk",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "copy-dir": "^1.2.0",
     "decompress": "^4.2.0",
     "diff": "^4.0.1",
+    "fast-glob": "^3.2.2",
     "find-java-home": "^1.0.1",
     "fs-extra": "^8.1.0",
     "ignore": "^5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,7 +1526,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
-fast-glob@^3.0.3:
+fast-glob@^3.0.3, fast-glob@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
   integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==


### PR DESCRIPTION
Apex Test Suite convert only worked in a specific scenario with the file paths mentioned in packageDir/main/default/apextestsuite, Any change will render the function to throw an error.

This fix is to utilize a glob to check the entire repository for the file and then process it.