### PR TITLE
fix: error messaging on sfdx:org:destruct failure

### DIFF
--- a/src/commands/sfpowerkit/org/destruct.ts
+++ b/src/commands/sfpowerkit/org/destruct.ts
@@ -196,8 +196,28 @@ export default class Destruct extends SfdxCommand {
           LoggerLevel.INFO
         );
     } else {
+      let componentFailures =
+        metadata_deploy_result.details["componentFailures"];
+      let errorResult = [];
+      if (componentFailures.constructor === Array) {
+        componentFailures.forEach(failure => {
+          errorResult.push({
+            componentType: failure.componentType,
+            fullName: failure.fullName,
+            problem: failure.problem
+          });
+        });
+      } else {
+        errorResult.push({
+          componentType: componentFailures.componentType,
+          fullName: componentFailures.fullName,
+          problem: componentFailures.problem
+        });
+      }
+
       throw new SfdxError(
-        `Unable to deploy the Destructive Changes: ${metadata_deploy_result.details["componentFailures"]["problem"]}`
+        "Unable to deploy the Destructive Changes: " +
+          JSON.stringify(errorResult)
       );
     }
   }


### PR DESCRIPTION
parsing the error message and printing in console.

issue #240 