### PR TITLE
fix: commit scratchorgs to pool early

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerkit",
-  "version": "1.45.2-12",
+  "version": "1.46.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -213,6 +213,9 @@
     "@istanbuljs/schema": {
       "version": "0.1.2",
       "dev": true
+    },
+    "@kwsites/exec-p": {
+      "version": "0.4.0"
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -5181,8 +5184,9 @@
       "version": "3.0.3"
     },
     "simple-git": {
-      "version": "1.132.0",
+      "version": "2.0.0",
       "requires": {
+        "@kwsites/exec-p": "^0.4.0",
         "debug": "^4.0.1"
       }
     },

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,0 +1,3050 @@
+{
+  "version": "1.46.0",
+  "commands": {
+    "sfpowerkit:auth:login": {
+      "id": "sfpowerkit:auth:login",
+      "description": "Login to an org using a username/password",
+      "usage": "<%= command.id %> -u <string> -p <string> [-s <string>] [-r <url>] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:auth:login -u azlam@sfdc.com -p Xasdax2w2  -a prod\n      Authorized to azlam@sfdc.com\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "username": {
+          "name": "username",
+          "type": "option",
+          "char": "u",
+          "description": "Username for the org",
+          "required": true
+        },
+        "password": {
+          "name": "password",
+          "type": "option",
+          "char": "p",
+          "description": "Password for the org",
+          "required": true
+        },
+        "securitytoken": {
+          "name": "securitytoken",
+          "type": "option",
+          "char": "s",
+          "description": "Security Token for the org",
+          "required": false
+        },
+        "url": {
+          "name": "url",
+          "type": "option",
+          "char": "r",
+          "description": "URL of the instance to be authenticated, Defaults to Test URL",
+          "required": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "option",
+          "char": "a",
+          "description": "Alias ofthe org",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:destruct": {
+      "id": "sfpowerkit:org:destruct",
+      "description": "This is a helper command to ease the deployment of destructiveChanges.xml. The command will create the empty package.xml and package the passed destructive manifest and deploy it to the org",
+      "usage": "<%= command.id %> [-m <filepath>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:destruct -m destructiveChanges.xml -u prod@prod3.com"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "option",
+          "char": "m",
+          "description": "The path to xml containing the members that need to be destructed,follow the instructions here to create such a file https://developer.salesforce.com/docs/atlas.en-us.daas.meta/daas/daas_destructive_changes.htm",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:healthcheck": {
+      "id": "sfpowerkit:org:healthcheck",
+      "description": "Gets the health details of an org",
+      "usage": "<%= command.id %> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:healthcheck  -u myOrg@example.com\n  Successfully Retrived the healthstatus of the org\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:orgcoverage": {
+      "id": "sfpowerkit:org:orgcoverage",
+      "description": "Gets the apex test coverage details of an org",
+      "usage": "<%= command.id %> [-d <string>] [-f json|csv] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$  sfdx sfpowerkit:org:orgcoverage  -u myOrg@example.com\n  sfdx sfpowerkit:org:orgcoverage  -u myOrg@example.com -d testResult -f csv\n  sfdx sfpowerkit:org:orgcoverage  -u myOrg@example.com -d testResult -f json\n\n\n  Successfully Retrieved the Apex Test Coverage of the org XXXX\n  coverage:85\n  ID     \t\tNAME                  TYPE          PERCENTAGE    COMMENTS                              UNCOVERED LINES\n  ───────\t\t──────────────────    ────────      ──────────\t  ───────────────────────────────────   ──────────────────\n  01pxxxx\t\tsampleController      ApexClass     100%\n  01pxxxx\t\tsampletriggerHandler  ApexClass\t    80%           Looks fine but target more than 85%   62;76;77;\n  01pxxxx\t\tsampleHelper          ApexClass\t    72%           Action required                       62;76;77;78;98;130;131\n  01qxxxx\t\tsampleTrigger         ApexTrigger   100%\n  Output testResult/output.csv is generated successfully\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "d",
+          "description": " The output dir where the output will be created",
+          "required": false
+        },
+        "format": {
+          "name": "format",
+          "type": "option",
+          "char": "f",
+          "description": " The format for the test result output, Possible values are json/csv",
+          "required": false,
+          "helpValue": "(json|csv)",
+          "options": ["json", "csv"]
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:relaxiprange": {
+      "id": "sfpowerkit:org:relaxiprange",
+      "description": "This command sets ip range in Network access to relax security setting for a particular salesforce environment",
+      "usage": "<%= command.id %> -r <array> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "sfdx sfpowerkit:org:relaxiprange -u sandbox -r \"122.0.0.0-122.255.255.255,49.0.0.0-49.255.255.255\""
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "range": {
+          "name": "range",
+          "type": "option",
+          "char": "r",
+          "description": "List of ip range with comma separated. eg, 122.0.0.0-122.255.255.255,49.0.0.0-49.255.255.255",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:valid": {
+      "id": "sfpowerkit:package:valid",
+      "description": "Validates a package to check whether it only contains valid metadata as per metadata coverage",
+      "usage": "<%= command.id %> [-n <string>] [-b <array>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:valid -n testPackage\n  Now analyzing testPackage\nConverting package testPackage\nElements supported included in your package testPackage are\n[\n  \"AuraDefinitionBundle\",\n  \"CustomApplication\",\n  \"ApexClass\",\n  \"ContentAsset\",\n  \"WorkflowRule\"\n]\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "n",
+          "description": "the package to analyze",
+          "required": false
+        },
+        "bypass": {
+          "name": "bypass",
+          "type": "option",
+          "char": "b",
+          "description": "metadatatypes to skip the package validation check",
+          "required": false
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "metadata API version to use for validation"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:pool:create": {
+      "id": "sfpowerkit:pool:create",
+      "description": "Creates a pool of prebuilt scratchorgs, which can the be consumed by users or CI",
+      "usage": "<%= command.id %> -f <filepath> [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:pool:create -f config\\core_poolconfig.json",
+        "$ sfdx sfpowerkit:pool:create -f config\\core_poolconfig.json -v devhub"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "configfilepath": {
+          "name": "configfilepath",
+          "type": "option",
+          "char": "f",
+          "description": "Relative Path to the pool configuration json file. The schema of the file could be found in the Wiki",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:pool:delete": {
+      "id": "sfpowerkit:pool:delete",
+      "description": "Deletes the pooled scratch orgs from the Scratch Org Pool",
+      "usage": "<%= command.id %> -t <string> [-m] [-a] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:pool:delete -t core ",
+        "$ sfdx sfpowerkit:pool:delete -t core -v devhub",
+        "$ sfdx sfpowerkit:pool:delete -t core -v devhub -m",
+        "$ sfdx sfpowerkit:pool:delete -t core -v devhub -m -a"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "tag": {
+          "name": "tag",
+          "type": "option",
+          "char": "t",
+          "description": "(required) tag used to identify the scratch org pool",
+          "required": true
+        },
+        "mypool": {
+          "name": "mypool",
+          "type": "boolean",
+          "char": "m",
+          "description": "Filter only Scratch orgs created by current user in the pool",
+          "required": false,
+          "allowNo": false
+        },
+        "allscratchorgs": {
+          "name": "allscratchorgs",
+          "type": "boolean",
+          "char": "a",
+          "description": "Deletes all used and unused Scratch orgs from pool by the tag",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:pool:fetch": {
+      "id": "sfpowerkit:pool:fetch",
+      "description": "Gets an active/unused scratch org from the scratch org pool",
+      "usage": "<%= command.id %> -t <string> [-m] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:pool:fetch -t core ",
+        "$ sfdx sfpowerkit:pool:fetch -t core -v devhub",
+        "$ sfdx sfpowerkit:pool:fetch -t core -v devhub -m"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "tag": {
+          "name": "tag",
+          "type": "option",
+          "char": "t",
+          "description": "(required) tag used to identify the scratch org pool",
+          "required": true
+        },
+        "mypool": {
+          "name": "mypool",
+          "type": "boolean",
+          "char": "m",
+          "description": "Filter the tag for any additions created  by the executor of the command",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:pool:list": {
+      "id": "sfpowerkit:pool:list",
+      "description": "Retrieves a list of active scratch org and details from any pool. If this command is run with -m|--mypool, the command will retrieve the passwords for the pool created by the user who is executing the command.",
+      "usage": "<%= command.id %> [-t <string>] [-m] [-a] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:pool:list -t core ",
+        "$ sfdx sfpowerkit:pool:list -t core -v devhub",
+        "$ sfdx sfpowerkit:pool:list -t core -v devhub -m",
+        "$ sfdx sfpowerkit:pool:list -t core -v devhub -m -a"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "tag": {
+          "name": "tag",
+          "type": "option",
+          "char": "t",
+          "description": "tag used to identify the scratch org pool",
+          "required": false
+        },
+        "mypool": {
+          "name": "mypool",
+          "type": "boolean",
+          "char": "m",
+          "description": "Filter the tag for any additions created  by the executor of the command",
+          "required": false,
+          "allowNo": false
+        },
+        "allscratchorgs": {
+          "name": "allscratchorgs",
+          "type": "boolean",
+          "char": "a",
+          "description": "Gets all used and unused Scratch orgs from pool",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:project:diff": {
+      "id": "sfpowerkit:project:diff",
+      "description": "Generate a delta 'changeset' between two diff commits so that  the incremental changes can be deployed to the target org.To be used for an org based deployment and the size of the metadata is large that the project cannot not be deployed in a single attempt./nThis command works with a source format based repository only. Utilize the command during a transition phase where an org is transformed to a modular architecture composing of multiple projects.",
+      "usage": "<%= command.id %> -r <string> -d <string> [-t <string>] [-x] [-b <array>] [-p <array>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:project:diff --diffFile DiffFileName --encoding EncodingOfFile --output OutputFolder",
+        "$ sfdx sfpowerkit:project:diff --revisionfrom revisionfrom --revisionto revisionto --output OutputFolder\n   "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "revisionfrom": {
+          "name": "revisionfrom",
+          "type": "option",
+          "char": "r",
+          "description": "Base revision from where diff is to be generated, required if diff file is ommited",
+          "required": true
+        },
+        "revisionto": {
+          "name": "revisionto",
+          "type": "option",
+          "char": "t",
+          "description": " [default:HEAD] Target revision to generate the diff ",
+          "required": false
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "d",
+          "description": " The output dir where the incremental project will be created",
+          "required": true
+        },
+        "generatedestructive": {
+          "name": "generatedestructive",
+          "type": "boolean",
+          "char": "x",
+          "description": "If set to true, the command will also generate a destructiveChangePost.xml file in the output folder.",
+          "required": false,
+          "allowNo": false
+        },
+        "bypass": {
+          "name": "bypass",
+          "type": "option",
+          "char": "b",
+          "description": "[EXPERIMENTAL] Ignore comma seperated paths from the diff being generated, the  diff command doesnt generate a diff on the following paths",
+          "required": false
+        },
+        "packagedirectories": {
+          "name": "packagedirectories",
+          "type": "option",
+          "char": "p",
+          "description": "[EXPERIMENTAL] Run diff only on specific paths, also generate a sfdx-project.json to support the corresponding package directory",
+          "required": false
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:project:orgdiff": {
+      "id": "sfpowerkit:project:orgdiff",
+      "description": "Compare source file again the salesforce and display differences. Can optionally add diff conflict markers on file to let the developer accept or rejest changes manually using a git merge tool.",
+      "usage": "<%= command.id %> -f <array> [-c] [-o json|csv] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:project:orgdiff --folder directory --noconflictmarkers --targetusername sandbox",
+        "$ sfdx sfpowerkit:project:orgdiff  --filename fileName --targetusername sandbox"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "filesorfolders": {
+          "name": "filesorfolders",
+          "type": "option",
+          "char": "f",
+          "description": "List of fils or folder to compare. Should be only Apex classes, trigger, Aura Components, Lightning Web Components or any unsplitted metadata.",
+          "required": true
+        },
+        "noconflictmarkers": {
+          "name": "noconflictmarkers",
+          "type": "boolean",
+          "char": "c",
+          "description": "If set to true, the command will not add diff conflict marker to each compared file.",
+          "required": false,
+          "allowNo": false
+        },
+        "outputformat": {
+          "name": "outputformat",
+          "type": "option",
+          "char": "o",
+          "description": " [default: json]The format for the diff output, Possible values are json/csv.",
+          "required": false,
+          "helpValue": "(json|csv)",
+          "options": ["json", "csv"]
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:pmd": {
+      "id": "sfpowerkit:source:pmd",
+      "description": "This command is a wrapper around PMD ( downloads PMD for the first time) with some predefined defaults, such as ruleset, output format, output file. The command is to be run from the project directory",
+      "usage": "<%= command.id %> [-d <string>] [-r <string>] [-f <string>] [-o <string>] [--javahome <string>] [--supressoutput] [--version <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": ["$ sfdx sfpowerkit:source:pmd"],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "directory": {
+          "name": "directory",
+          "type": "option",
+          "char": "d",
+          "description": "[default: Default project directory as mentioned in sfdx-project.json] Override this to set a different directory in the project folder",
+          "required": false
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "option",
+          "char": "r",
+          "description": "[default: sfpowerkit] The pmd ruleset that will be utilzied for analyzing the apex classes,  Checkout https://pmd.github.io/latest/pmd_userdocs_making_rulesets.html to create your own ruleset",
+          "required": false
+        },
+        "format": {
+          "name": "format",
+          "type": "option",
+          "char": "f",
+          "description": "[default: text] The format for the pmd output, Possible values are available at https://pmd.github.io/latest/pmd_userdocs_cli_reference.html#available-report-formats",
+          "required": false,
+          "default": "text"
+        },
+        "report": {
+          "name": "report",
+          "type": "option",
+          "char": "o",
+          "description": "[default: pmd-output] The path to where the output of the analysis should be written",
+          "required": false,
+          "default": "pmd-output"
+        },
+        "javahome": {
+          "name": "javahome",
+          "type": "option",
+          "description": "The command will try to locate the javahome path to execute PMD automatically, set this flag to override it to another javahome path",
+          "required": false
+        },
+        "supressoutput": {
+          "name": "supressoutput",
+          "type": "boolean",
+          "description": "[default: false] Supress the ouptut of the analysis to be displayed in the console",
+          "required": false,
+          "allowNo": false
+        },
+        "version": {
+          "name": "version",
+          "type": "option",
+          "description": "[default: 6.21.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory",
+          "required": false,
+          "default": "6.22.0"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:dependency:tree:package": {
+      "id": "sfpowerkit:dependency:tree:package",
+      "description": "This command is used to compute the dependency tree details of an unlocked package",
+      "usage": "<%= command.id %> -n <string> -o <string> [-p] [-s] [-f json|csv] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:dependency:tree:package -u MyScratchOrg -n 04txxxxxxxxxx -o outputdir -f json",
+        "$ sfdx sfpowerkit:dependency:tree:package -u MyScratchOrg -n 04txxxxxxxxxx -o outputdir -f csv",
+        "$ sfdx sfpowerkit:dependency:tree:package -u MyScratchOrg -n 04txxxxxxxxxx -o outputdir -f csv -p",
+        "$ sfdx sfpowerkit:dependency:tree:package -u MyScratchOrg -n 04txxxxxxxxxx -o outputdir -f csv -s"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "n",
+          "description": "package name, package version id, subscriber id that is installed in the org",
+          "required": true
+        },
+        "packagefilter": {
+          "name": "packagefilter",
+          "type": "boolean",
+          "char": "p",
+          "description": "output result will filter only dependent packages",
+          "required": false,
+          "allowNo": false
+        },
+        "showall": {
+          "name": "showall",
+          "type": "boolean",
+          "char": "s",
+          "description": "Indclude all items with/without dependency in the result",
+          "required": false,
+          "allowNo": false
+        },
+        "format": {
+          "name": "format",
+          "type": "option",
+          "char": "f",
+          "description": "format of the output file to create",
+          "required": false,
+          "helpValue": "(json|csv)",
+          "options": ["json", "csv"],
+          "default": "json"
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "o",
+          "description": "path to create the output",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:connectedapp:create": {
+      "id": "sfpowerkit:org:connectedapp:create",
+      "description": " Creates a connected app in the target org for JWT based authentication, Please note it only creates Connected App with All users may self authorize option, You would need to manually edit the policies to enable admin users are pre-approved and add your profile to this connected app",
+      "usage": "<%= command.id %> -n <string> -c <filepath> -e <email> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:connectedapp:create -u myOrg@example.com -n AzurePipelines -c id_rsa -e azlam.salamm@invalid.com\n  Created Connected App AzurePipelines in Target Org\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the connected app to be created",
+          "required": true
+        },
+        "pathtocertificate": {
+          "name": "pathtocertificate",
+          "type": "option",
+          "char": "c",
+          "description": "Filepath to the private certificate for the connected app to be created",
+          "required": true
+        },
+        "email": {
+          "name": "email",
+          "type": "option",
+          "char": "e",
+          "description": "Email of the connected app to be created",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:connectedapp:retrieve": {
+      "id": "sfpowerkit:org:connectedapp:retrieve",
+      "description": "Retrieves the consumer key for a connected app, Useful after a sandbox refresh in a CD Environment",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:connectedapp:retrieve -n AzurePipelines -u azlam@sfdc.com \n  Retrived AzurePipelines Consumer Key : XSD21Sd23123w21321\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the connected app to be retreived",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:duplicaterule:activate": {
+      "id": "sfpowerkit:org:duplicaterule:activate",
+      "description": "Activates a duplicate rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:duplicaterule:Activate -n Account.CRM_Account_Rule_1 -u sandbox\n    Polling for Retrieval Status\n    Retrieved Duplicate Rule  with label : CRM Account Rule 2\n    Preparing Activation\n    Deploying Activated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Duplicate Rule CRM Account Rule 2 Activated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the duplicate rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:duplicaterule:deactivate": {
+      "id": "sfpowerkit:org:duplicaterule:deactivate",
+      "description": "Deactivates a duplicate rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:duplicaterule:deactivate -n Account.CRM_Account_Rule_1 -u sandbox\n    Polling for Retrieval Status\n    Retrieved Duplicate Rule  with label : CRM Account Rule 2\n    Preparing Deactivation\n    Deploying Deactivated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Duplicate Rule CRM Account Rule 2 deactivated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the duplicate rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:manifest:build": {
+      "id": "sfpowerkit:org:manifest:build",
+      "description": "Generate a complete manifest of all the metadata from the specified org. Once the manifest is generated use source:retrieve or mdapi:retrieve to retrieve the metadata.",
+      "usage": "<%= command.id %> [-q <string>] [-x] [-o <filepath>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml\n    <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n    <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">...</Package>\n    ",
+        "$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -q 'ApexClass, CustomObject, Report' \n    <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n    <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">...</Package>\n    "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "quickfilter": {
+          "name": "quickfilter",
+          "type": "option",
+          "char": "q",
+          "description": "comma separated values  of metadata type, member or file names to be excluded while building the manifest"
+        },
+        "excludemanaged": {
+          "name": "excludemanaged",
+          "type": "boolean",
+          "char": "x",
+          "description": "exclude managed packages components from the manifest",
+          "allowNo": false
+        },
+        "outputfile": {
+          "name": "outputfile",
+          "type": "option",
+          "char": "o",
+          "description": "The output path where the manifest file will be created"
+        }
+      },
+      "args": [{ "name": "file" }]
+    },
+    "sfpowerkit:org:matchingrule:activate": {
+      "id": "sfpowerkit:org:matchingrule:activate",
+      "description": "Activates a matching rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:matchingrules:activate -n Account -u sandbox\n    Polling for Retrieval Status\n    Retrieved Matching Rule  for Object : Account\n    Preparing Activation\n    Deploying Activated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Matching Rule for  Account activated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the object that has the matching rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:matchingrule:deactivate": {
+      "id": "sfpowerkit:org:matchingrule:deactivate",
+      "description": "Deactivates a matching rule in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:matchingrules:deactivate -n Account -u sandbox\n    Polling for Retrieval Status\n    Retrieved Matching Rule  for Object : Account\n    Preparing Deactivation\n    Deploying Deactivated Rule with ID  0Af4Y000003OdTWSA0\n    Polling for Deployment Status\n    Polling for Deployment Status\n    Matching Rule for  Account deactivated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the object that has the matching rule",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:orgwideemail:create": {
+      "id": "sfpowerkit:org:orgwideemail:create",
+      "description": "This command is deprecated, Please update your workflows..Create an orgWide Email Address",
+      "usage": "<%= command.id %> -e <email> -n <string> [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "sfdx sfpowerkit:org:orgwideemail:create -e testuser@test.com  -u scratch1 -n \"Test Address\" -p\n     Creating email azlam.abdulsalam@accenture.com\n     Org wide email created with Id 0D2210000004DidCAE\n     Run the folowing command to verify it\n    sfdx sfpowerkit:org:orgwideemail:verify -i 0D2210000004DidCAE -u test-jkomdylblorj@example.com  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "address": {
+          "name": "address",
+          "type": "option",
+          "char": "e",
+          "description": "Org Wide address email",
+          "required": true
+        },
+        "displayname": {
+          "name": "displayname",
+          "type": "option",
+          "char": "n",
+          "description": "Org Wide address display name",
+          "required": true
+        },
+        "allprofile": {
+          "name": "allprofile",
+          "type": "boolean",
+          "char": "p",
+          "description": "Allow for all profile",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:orgwideemail:verify": {
+      "id": "sfpowerkit:org:orgwideemail:verify",
+      "description": "This command is deprecated, Please update your workflows..Verify an already created orgWide Email Address",
+      "usage": "<%= command.id %> -i <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:orgwideemail:verify --username scratchOrg --emailid orgwideemailid\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "emailid": {
+          "name": "emailid",
+          "type": "option",
+          "char": "i",
+          "description": "Id of the Org Wide address email to verify",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:profile:diff": {
+      "id": "sfpowerkit:org:profile:diff",
+      "description": "Compare profiles from project against target org or between two orgs (source and target)",
+      "usage": "<%= command.id %> [-p <array>] [-s <string>] [-d <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:profile:diff --profilelist profilenames --targetusername username (Compare liste profiles path against target org)",
+        "$ sfdx sfpowerkit:org:profile:diff --targetusername username (compare all profile in the project against the target org)",
+        "$ sfdx sfpowerkit:org:profile:diff --sourceusername sourcealias --targetusername username (compare all profile in the source org against the target org)"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "profilelist": {
+          "name": "profilelist",
+          "type": "option",
+          "char": "p",
+          "description": "List of profiles to compare, comma separated profile names. If not provided and no sourceusername is provided, all profiles from the source folder will be processed.",
+          "required": false
+        },
+        "sourceusername": {
+          "name": "sourceusername",
+          "type": "option",
+          "char": "s",
+          "description": "Source org. If no profile is provided in the profilelist parameter, all the profile from this org will be fetched",
+          "required": false
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "d",
+          "description": "Output folder. Provide the output folder if comparing profiles from source org.",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:sandbox:create": {
+      "id": "sfpowerkit:org:sandbox:create",
+      "description": "Creates a sandbox using the tooling api, ensure the user has the required permissions before using this command",
+      "usage": "<%= command.id %> -n <string> -d <string> -l <string> [-a <string>] [-f <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:sandbox:create -d Testsandbox -l DEVELOPER -n test2 -u myOrg@example.com\n  Successfully Enqueued Creation of Sandbox\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the sandbox",
+          "required": true
+        },
+        "description": {
+          "name": "description",
+          "type": "option",
+          "char": "d",
+          "description": "Description of the sandbox",
+          "required": true
+        },
+        "licensetype": {
+          "name": "licensetype",
+          "type": "option",
+          "char": "l",
+          "description": "Type of the sandbox. Valid values are  DEVELOPER,DEVELOPER_PRO,PARTIAL,FULL",
+          "required": true,
+          "options": ["DEVELOPER", "DEVELOPER_PRO", "PARTIAL", "FULL"]
+        },
+        "apexclass": {
+          "name": "apexclass",
+          "type": "option",
+          "char": "a",
+          "description": "A reference to the ID of an Apex class that runs after each copy of the sandbox",
+          "required": false,
+          "default": ""
+        },
+        "clonefrom": {
+          "name": "clonefrom",
+          "type": "option",
+          "char": "f",
+          "description": "A reference to the ID of a SandboxInfo that serves as the source org for a cloned sandbox.",
+          "required": false,
+          "default": ""
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:sandbox:info": {
+      "id": "sfpowerkit:org:sandbox:info",
+      "description": "Gets the status of a sandbox",
+      "usage": "<%= command.id %> -n <string> [-s] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:sandbox:info -n test2  -v produser@example.com \n  Successfully Enqueued Refresh of Sandbox\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the sandbox",
+          "required": true
+        },
+        "showonlylatest": {
+          "name": "showonlylatest",
+          "type": "boolean",
+          "char": "s",
+          "description": "Shows only the latest info of the sandbox record",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:sandbox:refresh": {
+      "id": "sfpowerkit:org:sandbox:refresh",
+      "description": "Refresh a sandbox using the tooling api, ensure the user has the required permissions before using this command",
+      "usage": "<%= command.id %> -n <string> [-f <string>] [-l <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:sandbox:refresh -n test2  -f sitSandbox -v myOrg@example.com\n  Successfully Enqueued Refresh of Sandbox\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the sandbox",
+          "required": true
+        },
+        "clonefrom": {
+          "name": "clonefrom",
+          "type": "option",
+          "char": "f",
+          "description": "Name of the SandboxInfo that serves as the source org for a cloned sandbox.",
+          "required": false,
+          "default": ""
+        },
+        "licensetype": {
+          "name": "licensetype",
+          "type": "option",
+          "char": "l",
+          "description": "Type of the sandbox. Valid values are  DEVELOPER,DEVELOPER_PRO,PARTIAL,FULL, Provide this if the sandbox is to be rereshed from Production",
+          "required": false,
+          "options": ["DEVELOPER", "DEVELOPER_PRO", "PARTIAL", "FULL"]
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:scratchorg:delete": {
+      "id": "sfpowerkit:org:scratchorg:delete",
+      "description": "Gets the active count of scratch org by users in a devhub",
+      "usage": "<%= command.id %> -e <string> [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:scratchorg:delete  -e xyz@kyz.com -v devhub\n    Found Scratch Org Ids for user xyz@kyz.com\n    2AS6F000000XbxVWAS\n    Deleting Scratch Orgs\n    Deleted Scratch Org 2AS6F000000XbxVWAS\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "email": {
+          "name": "email",
+          "type": "option",
+          "char": "e",
+          "description": "Email of the user account that has created the scratch org",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:scratchorg:usage": {
+      "id": "sfpowerkit:org:scratchorg:usage",
+      "description": "Gets the active count of scratch org by users in a devhub",
+      "usage": "<%= command.id %> [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:scratchorg:usage -v devhub\n    Active Scratch Orgs Remaining: 42 out of 100\n    Daily Scratch Orgs Remaining: 171 out of 200\n\n    SCRATCH_ORGS_USED  NAME\n    ─────────────────  ─────────────────\n    2                  XYZ@KYZ.COM\n    2                  JFK@KYZ.COM\n    Total number of records retrieved: 4.\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:trigger:activate": {
+      "id": "sfpowerkit:org:trigger:activate",
+      "description": "Activates a trigger in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:trigger:activate -n AccountTrigger -u sandbox\n    Polling for Retrieval Status\n    Preparing Activation\n    Deploying Activated ApexTrigger with ID  0Af4Y000003Q7GySAK\n    Polling for Deployment Status\n    Polling for Deployment Status\n    ApexTrigger AccountTrigger Activated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the trigger that has to be activated",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:org:trigger:deactivate": {
+      "id": "sfpowerkit:org:trigger:deactivate",
+      "description": "Deactivates a trigger in the target org",
+      "usage": "<%= command.id %> -n <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:org:trigger:deactivate -n AccountTrigger -u sandbox\n    Polling for Retrieval Status\n    Preparing Deactivation\n    Deploying Deactivated ApexTrigger with ID  0Af4Y000003Q7GySAK\n    Polling for Deployment Status\n    Polling for Deployment Status\n    ApexTrigger AccountTrigger deactivated\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the trigger that has to be deactivated",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:dependencies:install": {
+      "id": "sfpowerkit:package:dependencies:install",
+      "description": "Install dependencies of a package",
+      "usage": "<%= command.id %> [-p <string>] [-k <string>] [-b <string>] [-w <string>] [-r] [-o] [-a] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:dependencies:install -u MyScratchOrg -v MyDevHub -k \"1:MyPackage1Key 2: 3:MyPackage3Key\" -b \"DEV\""
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "individualpackage": {
+          "name": "individualpackage",
+          "type": "option",
+          "char": "p",
+          "description": "Installs a specific package especially for upgrade scenario",
+          "required": false
+        },
+        "installationkeys": {
+          "name": "installationkeys",
+          "type": "option",
+          "char": "k",
+          "description": "installation key for key-protected packages (format is 1:MyPackage1Key 2: 3:MyPackage3Key... to allow some packages without installation key)",
+          "required": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "option",
+          "char": "b",
+          "description": "the package version’s branch",
+          "required": false
+        },
+        "wait": {
+          "name": "wait",
+          "type": "option",
+          "char": "w",
+          "description": "number of minutes to wait for installation status (also used for publishwait). Default is 10",
+          "required": false
+        },
+        "noprompt": {
+          "name": "noprompt",
+          "type": "boolean",
+          "char": "r",
+          "description": "allow Remote Site Settings and Content Security Policy websites to send or receive data without confirmation",
+          "required": false,
+          "allowNo": false
+        },
+        "updateall": {
+          "name": "updateall",
+          "type": "boolean",
+          "char": "o",
+          "description": "Update all packages even if they are installed in the target org",
+          "required": false,
+          "allowNo": false
+        },
+        "apexcompileonlypackage": {
+          "name": "apexcompileonlypackage",
+          "type": "boolean",
+          "char": "a",
+          "description": "Compile the apex only in the package, by default only the compilation of the apex in the entire org is triggered",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:version:codecoverage": {
+      "id": "sfpowerkit:package:version:codecoverage",
+      "description": "This command is used to get the apex test coverage details of an unlocked package",
+      "usage": "<%= command.id %> [-p <string>] [-n <string>] [-i <array>] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:version:codecoverage -v myOrg@example.com -i 04tXXXXXXXXXXXXXXX \n",
+        "$ sfdx sfpowerkit:package:version:codecoverage -v myOrg@example.com -i 04tXXXXXXXXXXXXXXX,04tXXXXXXXXXXXXXXX,04tXXXXXXXXXXXXXXX \n",
+        "$ sfdx sfpowerkit:package:version:codecoverage -v myOrg@example.com -p core -n 1.2.0.45 \n",
+        "$ sfdx sfpowerkit:package:version:codecoverage -v myOrg@example.com -p 0HoXXXXXXXXXXXXXXX -n 1.2.0.45"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "API version"
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "char": "p",
+          "description": "Name of the unlocked package to check the code coverage, packageVersionNumber is required when packageName is used",
+          "required": false
+        },
+        "versionnumber": {
+          "name": "versionnumber",
+          "type": "option",
+          "char": "n",
+          "description": "The complete version number format is major.minor.patch (Beta build)—for example, 1.2.0 (Beta 5), packageName is required when packageVersionNumber is used",
+          "required": false
+        },
+        "versionid": {
+          "name": "versionid",
+          "type": "option",
+          "char": "i",
+          "description": "Package version Id to check the code coverage",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:version:info": {
+      "id": "sfpowerkit:package:version:info",
+      "description": "This command is list all the installed (managed/unmanaged) packages in an org",
+      "usage": "<%= command.id %> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:version:info -u myOrg@example.com "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "API version"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:project:manifest:diff": {
+      "id": "sfpowerkit:project:manifest:diff",
+      "description": "run diff between two package.xml and get the difference",
+      "usage": "<%= command.id %> -s <string> -t <string> -d <string> [-f json|csv|xml] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:project:manifest:diff -s source/package.xml -t target/package.xml -d output"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "sourcepath": {
+          "name": "sourcepath",
+          "type": "option",
+          "char": "s",
+          "description": "Paths to the source package.xml file",
+          "required": true
+        },
+        "targetpath": {
+          "name": "targetpath",
+          "type": "option",
+          "char": "t",
+          "description": "Paths to the target package.xml file",
+          "required": true
+        },
+        "output": {
+          "name": "output",
+          "type": "option",
+          "char": "d",
+          "description": "path to the diff output package.xml",
+          "required": true
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "The api version to be used create package.xml"
+        },
+        "format": {
+          "name": "format",
+          "type": "option",
+          "char": "f",
+          "description": "[default: json] The format for the output, Possible values are json/csv/xml",
+          "required": false,
+          "helpValue": "(json|csv|xml)",
+          "options": ["json", "csv", "xml"],
+          "default": "json"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:project:manifest:merge": {
+      "id": "sfpowerkit:project:manifest:merge",
+      "description": "Merge multiple package.xml into single collective package.xml",
+      "usage": "<%= command.id %> -p <array> -d <string> [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:project:manifest:merge -p project1/path/to/package.xml -d result/package.xml\n$ sfdx sfpowerkit:project:manifest:merge -p project1/path/to/package.xml,project2/path/to/package.xml -d result/package.xml"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "char": "p",
+          "description": "Paths to the package.xml file",
+          "required": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "option",
+          "char": "d",
+          "description": "output path to create collective package.xml",
+          "required": true
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "The api version to be used create package.xml"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:apextestsuite:convert": {
+      "id": "sfpowerkit:source:apextestsuite:convert",
+      "description": "Converts an apex test suite to its consituent apex classes as a single line separated by commas, so that it can be used for metadata api deployment",
+      "usage": "<%= command.id %> -n <string> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:apextestsuite:convert -n MyApexTestSuite \n    \"ABC2,ABC1Test\"    \n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "char": "n",
+          "description": "The name of the apextestsuite (the file name minus the apex test suite)",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:customlabel:buildmanifest": {
+      "id": "sfpowerkit:source:customlabel:buildmanifest",
+      "description": "This Command is used to build package.xml with all customlabels as members rather than wildcard *. sfdx force:source:convert creates a package.xml with customlabels wildcard, this command helps to update the package.xml with list of label names.",
+      "usage": "<%= command.id %> -p <array> -x <string> [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:customlabel:buildmanifest -p project1/path/to/customlabelfile.xml -x mdapiout/package.xml\n$ sfdx sfpowerkit:source:customlabel:buildmanifest -p project1/path/to/customlabelfile.xml,project2/path/to/customlabelfile.xml -x mdapiout/package.xml"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "[default: info] logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "char": "p",
+          "description": "Path to the CustomLabels.labels-meta.xml file",
+          "required": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "option",
+          "char": "x",
+          "description": "path to existing package.xml file or create new package.xml",
+          "required": true
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "The api version to be used create package.xml"
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:customlabel:create": {
+      "id": "sfpowerkit:source:customlabel:create",
+      "description": "Custom Labels are org wide, hence when the metadata is pulled down from scratch org, the entire custom label metadata file is updated in a package repo. This command is a helper command to create customlabel with pacakage names prepended for easy reconcilation.",
+      "usage": "<%= command.id %> -n <string> -v <string> -s <string> [-c <string>] [-l <string>] [-p <string>] [--package <string>] [-i] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:customlabel:create -u fancyScratchOrg1 -n FlashError -v \"Memory leaks aren't for the faint hearted\" -s \"A flashing error --package core\"\n  Deployed CustomLabel FlashError in target org with core_  prefix, You may now pull and utilize the customlabel:reconcile command\n  "
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "fullname": {
+          "name": "fullname",
+          "type": "option",
+          "char": "n",
+          "description": "Name of the custom label (API Name)",
+          "required": true
+        },
+        "value": {
+          "name": "value",
+          "type": "option",
+          "char": "v",
+          "description": "Value of the custom label",
+          "required": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "option",
+          "char": "c",
+          "description": "Comma Separated Category Values",
+          "required": false
+        },
+        "language": {
+          "name": "language",
+          "type": "option",
+          "char": "l",
+          "description": "Language of the custom label (Default: en_US)",
+          "required": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "option",
+          "char": "p",
+          "description": "Protected State of the custom label (Default: false)",
+          "required": false
+        },
+        "shortdescription": {
+          "name": "shortdescription",
+          "type": "option",
+          "char": "s",
+          "description": "Short Description of the custom label",
+          "required": true
+        },
+        "package": {
+          "name": "package",
+          "type": "option",
+          "description": "The name of the package that needs to be appended",
+          "required": false
+        },
+        "ignorepackage": {
+          "name": "ignorepackage",
+          "type": "boolean",
+          "char": "i",
+          "description": "Ignores the addition of the package into the fullname (API Name)",
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:customlabel:reconcile": {
+      "id": "sfpowerkit:source:customlabel:reconcile",
+      "description": "Custom Labels are org wide, hence when the metadata is pulled down from scratch org, the entire custom label metadata file is updated in a package repo, This command reconcile the updated custom labels to include only the labels that have the API name starting with package name or created using the custom label create command",
+      "usage": "<%= command.id %> -d <string> -p <string> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:customlabel:reconcile -d path/to/customlabelfile.xml -p core\n    Cleaned The Custom Labels\n"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "path": {
+          "name": "path",
+          "type": "option",
+          "char": "d",
+          "description": "Path to the CustomLabels.labels-meta.xml file",
+          "required": true
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "char": "p",
+          "description": "The name of the package that needs to be reconciled",
+          "required": true
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:profile:merge": {
+      "id": "sfpowerkit:source:profile:merge",
+      "description": "This command is used in the lower environments such as ScratchOrgs , Development / System Testing Sandboxes, inorder to apply the changes made in the environment to retrieved profile, so that it can be deployed to the higher environments",
+      "usage": "<%= command.id %> [-f <array>] [-n <array>] [-m <array>] [-d] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:profile:merge -u sandbox",
+        "$ sfdx sfpowerkit:source:profile:merge -f force-app -n \"My Profile\" -r -u sandbox",
+        "$ sfdx sfpowerkit:source:profile:merge -f \"module1, module2, module3\" -n \"My Profile1, My profile2\"  -u sandbox"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "option",
+          "char": "f",
+          "description": "comma separated list of folders to scan for profiles. If ommited, the folders in the packageDirectories configuration will be used.",
+          "required": false
+        },
+        "profilelist": {
+          "name": "profilelist",
+          "type": "option",
+          "char": "n",
+          "description": "comma separated list of profiles. If ommited, all the profiles found in the folder(s) will be merged",
+          "required": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "option",
+          "char": "m",
+          "description": "comma separated list of metadata for which the permissions will be retrieved.",
+          "required": false
+        },
+        "delete": {
+          "name": "delete",
+          "type": "boolean",
+          "char": "d",
+          "description": "set this flag to delete profile files that does not exist in the org.",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:profile:reconcile": {
+      "id": "sfpowerkit:source:profile:reconcile",
+      "description": "This command is used in the lower environments such as ScratchOrgs , Development / System Testing Sandboxes, where a retrieved profile from production has to be cleaned up only for the metadata that is contained in the environment or  base it only as per the metadata that is contained in the packaging directory.",
+      "usage": "<%= command.id %> [-f <array>] [-n <array>] [-d <directory>] [-s] [-u <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:profile:reconcile  --folder force-app -d destfolder -s",
+        "$ sfdx sfpowerkit:source:profile:reconcile  --folder force-app,module2,module3 -u sandbox -d destfolder",
+        "$ sfdx sfpowerkit:source:profile:reconcile  -u myscratchorg -d destfolder"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "option",
+          "char": "f",
+          "description": "path to the folder which contains the profiles to be reconciled,if project contain multiple package directories, please provide a comma seperated list, if omitted, all the package directories will be checked for profiles",
+          "required": false
+        },
+        "profilelist": {
+          "name": "profilelist",
+          "type": "option",
+          "char": "n",
+          "description": "list of profiles to be reconciled. If ommited, all the profiles components will be reconciled.",
+          "required": false
+        },
+        "destfolder": {
+          "name": "destfolder",
+          "type": "option",
+          "char": "d",
+          "description": " the destination folder for reconciled profiles, if omitted existing profiles will be reconciled and will be rewritten in the current location",
+          "required": false
+        },
+        "sourceonly": {
+          "name": "sourceonly",
+          "type": "boolean",
+          "char": "s",
+          "description": "set this flag to reconcile profiles only against component available in the project only. Configure ignored perissions in sfdx-project.json file in the array plugins->sfpowerkit->ignoredPermissions.",
+          "required": false,
+          "allowNo": false
+        },
+        "targetorg": {
+          "name": "targetorg",
+          "type": "option",
+          "char": "u",
+          "description": " org against which profiles will be reconciled. this parameter can be ommited if sourceonly flag is set.",
+          "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:source:profile:retrieve": {
+      "id": "sfpowerkit:source:profile:retrieve",
+      "description": "Retrieve profiles from the salesforce org with all its associated permissions. Common use case for this command is  to migrate profile changes from a integration environment to other higher environments [overcomes SFDX CLI Profile retrieve issue where it doesnt fetch the full profile unless the entire metadata is present in source], or retrieving profiles from production to lower environments for testing.",
+      "usage": "<%= command.id %> [-f <array>] [-n <array>] [-d] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:source:profile:retrieve -u prod",
+        "$ sfdx sfpowerkit:source:profile:retrieve  -f force-app -n \"My Profile\" -u prod",
+        "$ sfdx sfpowerkit:source:profile:retrieve  -f \"module1, module2, module3\" -n \"My Profile1, My profile2\"  -u prod"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "info"
+        },
+        "targetusername": {
+          "name": "targetusername",
+          "type": "option",
+          "char": "u",
+          "description": "username or alias for the target org; overrides default target org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "option",
+          "char": "f",
+          "description": "retrieve only updated versions of profiles found in this directory, If ignored, all profiles will be retrieved.",
+          "required": false
+        },
+        "profilelist": {
+          "name": "profilelist",
+          "type": "option",
+          "char": "n",
+          "description": "comma separated list of profiles to be retrieved. Use it for selectively retrieving an existing profile or retrieving a new profile",
+          "required": false
+        },
+        "delete": {
+          "name": "delete",
+          "type": "boolean",
+          "char": "d",
+          "description": "set this flag to delete profile files that does not exist in the org, when retrieving in bulk",
+          "required": false,
+          "allowNo": false
+        }
+      },
+      "args": []
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerkit",
   "description": "A Salesforce DX Plugin with multiple functionalities aimed at improving development and operational workflows",
-  "version": "1.45.2-12",
+  "version": "1.46.0",
   "author": {
     "name": "DXatScale",
     "email": "dxatscale@accenture.com"
@@ -19,10 +19,6 @@
     {
       "name": "Manivasaga Murugesan",
       "email": "manivasaga.murugesan@accenture.com"
-    },
-    {
-      "name": "Ahmed Abdo",
-      "email": "abdo@abdokhaire.com"
     }
   ],
   "bugs": "https://github.com/accenture/sfpowerkit/issues",
@@ -47,7 +43,7 @@
     "pino-pretty": "^3.5.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
-    "simple-git": "^1.129.0",
+    "simple-git": "2.0.0",
     "ts-node": "^8.10.1",
     "tslib": "1",
     "unzip-stream": "0.3.0",

--- a/src/commands/sfpowerkit/pool/delete.ts
+++ b/src/commands/sfpowerkit/pool/delete.ts
@@ -74,6 +74,6 @@ export default class Delete extends SfdxCommand {
       }
     }
 
-    return JSON.stringify(result);
+    return result as AnyJson;
   }
 }

--- a/src/commands/sfpowerkit/pool/fetch.ts
+++ b/src/commands/sfpowerkit/pool/fetch.ts
@@ -66,6 +66,6 @@ export default class Fetch extends SfdxCommand {
       this.ux.table(list, ["key", "value"]);
     }
 
-    return JSON.stringify(result);
+    return result as AnyJson;
   }
 }

--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -219,8 +219,8 @@ export default class PoolCreateImpl {
       );
     } else {
       SFPowerkit.log(
-        `Request for provisioning ${this.totalToBeAllocated} scratchOrgs of which ${this.totalAllocated} were allocated with ${commit_result.success} success and ${commit_result.failed} failures`,
-        LoggerLevel.INFO
+        `Request for provisioning ${this.totalToBeAllocated} scratchOrgs not successfull.`,
+        LoggerLevel.ERROR
       );
     }
     return true;
@@ -229,7 +229,7 @@ export default class PoolCreateImpl {
   private validateScriptFile() {
     if (isNullOrUndefined(this.poolConfig.pool.script_file_path)) {
       SFPowerkit.log(
-        "Script Path not provided, will crete a pool of scratch orgs without any post creation steps",
+        "Script Path not provided, will create a pool of scratch orgs without any post creation steps",
         LoggerLevel.WARN
       );
       this.scriptFileExists = false;

--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -381,10 +381,17 @@ export default class PoolCreateImpl {
 
         try {
           //Delete scratchorgs that failed to execute script
-          await ScratchOrgUtils.deleteScratchOrg(
+
+          let activeScratchOrgRecordId = await ScratchOrgUtils.getActiveScratchOrgRecordIdGivenScratchOrg(
             this.hubOrg,
             this.apiversion,
             scratchOrg.recordId
+          );
+
+          await ScratchOrgUtils.deleteScratchOrg(
+            this.hubOrg,
+            this.apiversion,
+            activeScratchOrgRecordId
           );
         } catch (error) {
           SFPowerkit.log(

--- a/src/impl/project/diff/diffUtil.ts
+++ b/src/impl/project/diff/diffUtil.ts
@@ -7,7 +7,7 @@ import { SOURCE_EXTENSION_REGEX } from "../../../impl/metadata/metadataInfo";
 import { METADATA_INFO } from "../../../impl/metadata/metadataInfo";
 import { SFPowerkit } from "../../../sfpowerkit";
 import { LoggerLevel } from "@salesforce/core";
-import simplegit from "simple-git/promise";
+import simplegit, { SimpleGit } from "simple-git/promise";
 
 export interface DiffFileStatus {
   revisionFrom: string;
@@ -21,7 +21,7 @@ export interface DiffFile {
   addedEdited: DiffFileStatus[];
 }
 
-const git = simplegit();
+const git: SimpleGit = simplegit();
 
 export default class DiffUtil {
   public static gitTreeRevisionTo: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,6 +209,11 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
+"@kwsites/exec-p@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@kwsites/exec-p/-/exec-p-0.4.0.tgz#ab3765d482849ba6e825721077c248cf9f3323b7"
+  integrity sha512-44DWNv5gDR9EwrCTVQ4ZC99yPqVS0VCWrYIBl45qNR8XQy+4lbl0IQG8kBDf6NHwj4Ib4c2z1Fq1IUJOCbkZcw==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -4941,11 +4946,12 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-simple-git@^1.129.0:
-  version "1.132.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.132.0.tgz#53ac4c5ec9e74e37c2fd461e23309f22fcdf09b1"
-  integrity sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==
+simple-git@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.0.0.tgz#bbd00f809fdb404dcbc2fdc2d4c5c1a0956694dc"
+  integrity sha512-R7P9WfnHmwnUlRowXGT93FOhhGvRQWWGhgH6Nf3lCXOv4SjtAuK25Tfhf4VFYueQ11r4WDMUVLXtKFGWPwLehg==
   dependencies:
+    "@kwsites/exec-p" "^0.4.0"
     debug "^4.0.1"
 
 sinon@^8.0.4:


### PR DESCRIPTION
ScratchOrgs are only committed to the pool only after only scripts are completed across all the scratchorgs. This fix  is to bring
the commit early, so any scratchorg that is finished execution will be committed to the pool immediately.

The logs for execution of scripts in individual scratch org's will be stored in script_exec_outputs folder