### PR TITLE
Fix Pipeline Failure on MacOs and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sfpowerkit
 
-[![NPM](https://img.shields.io/npm/v/sfpowerkit.svg)](https://www.npmjs.com/package/sfpowerkit) ![npm (tag)](https://img.shields.io/npm/v/sfpowerkit/beta) [![Build status](https://dev.azure.com/dxatscale/sfpowerkit/_apis/build/status/SFPowerkit-CI?branchName=master)](https://dev.azure.com/dxatscale/SFPowerkit/_build/latest?definitionId=5) [![Greenkeeper badge](https://badges.greenkeeper.io/Accenture/sfpowerkit.svg)](https://greenkeeper.io/)![npm](https://img.shields.io/npm/dw/sfpowerkit)
+[![NPM](https://img.shields.io/npm/v/sfpowerkit.svg)](https://www.npmjs.com/package/sfpowerkit) ![npm (tag)](https://img.shields.io/npm/v/sfpowerkit/beta) [![Build Status](https://dev.azure.com/dxatscale/sfpowerkit/_apis/build/status/Release?branchName=master)](https://dev.azure.com/dxatscale/sfpowerkit/_build/latest?definitionId=48&branchName=master) ![npm](https://img.shields.io/npm/dw/sfpowerkit)
 
 A Salesforce DX Plugin with multiple functionalities aimed at improving development and operational workflows
 Read the blog here https://accenture.github.io/blog/2019/06/27/sfpowerkit.html

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -40,6 +40,7 @@ stages:
           - template: templates/smoke-test-template.yml
             parameters:
               version: alpha
+              platform: $(image)
 
   - stage: Beta
     displayName: Beta
@@ -96,6 +97,7 @@ stages:
           - template: templates/smoke-test-template.yml
             parameters:
               version: hotfix
+              platform: $(image)
 
   - stage: Prod
     displayName: Prod
@@ -117,3 +119,4 @@ stages:
                 - template: templates/build-template.yml
                   parameters:
                     version: latest
+

--- a/templates/build-template.yml
+++ b/templates/build-template.yml
@@ -33,6 +33,7 @@ steps:
 
   - task: CmdLine@2
     displayName: Run Yarn
+    continueOnError: true
     condition: or(eq( '${{ parameters.version }}', 'alpha'), eq( '${{ parameters.version }}', 'hotfix'), eq( '${{ parameters.version }}', 'review') )
     inputs:
       script: "yarn"

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -9,15 +9,22 @@ parameters:
 
 steps:
   - task: sfpwowerscript-installsfdx-task@7
+    condition: ne( '${{ parameters.version }}', 'review')
     displayName: "Install SFDX"
     inputs:
       sfpowerkit_version: ${{ parameters.version }}
+
+  - task: sfpwowerscript-installsfdx-task@7
+    condition: eq( '${{ parameters.version }}', 'review')
+    displayName: "Install SFDX"
+    inputs:
+      sfpowerkit_version: latest
 
   - task: CmdLine@2
     condition: eq( '${{ parameters.platform }}', 'macOS-latest')
     displayName: "Install sfpowerkit"
     inputs:
-       script: |
+      script: |
         echo y | sfdx plugins:install sfpowerkit
 
   - task: CmdLine@2

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -3,18 +3,22 @@ parameters:
     type: string
     default: alpha
 
+  - name: platform
+    type: string
+    default: ubuntu
+
 steps:
   - task: sfpwowerscript-installsfdx-task@7
-    condition: ne( '${{ parameters.version }}', 'review')
     displayName: "Install SFDX"
     inputs:
       sfpowerkit_version: ${{ parameters.version }}
 
-  - task: sfpwowerscript-installsfdx-task@7
-    condition: eq( '${{ parameters.version }}', 'review')
-    displayName: "Install SFDX"
+  - task: CmdLine@2
+    condition: eq( '${{ parameters.platform }}', 'macOS-latest')
+    displayName: "Install sfpowerkit"
     inputs:
-      sfpowerkit_version: latest
+       script: |
+        echo y | sfdx plugins:install sfpowerkit
 
   - task: CmdLine@2
     condition: eq( '${{ parameters.version }}', 'review')


### PR DESCRIPTION
- sfpowerscripts is not supported on Mac, Install Manually
- Pass platform parameter to the pipeline
- Set Continue on error for Publish