### PR TITLE
Fix missing log files  in Scratch Org create command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerkit",
   "description": "A Salesforce DX Plugin with multiple functionalities aimed at improving development and operational workflows",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "author": {
     "name": "DXatScale",
     "email": "dxatscale@accenture.com"

--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -149,6 +149,12 @@ export default class PoolCreateImpl {
     //Generate Scratch Orgs
     await this.generateScratchOrgs();
 
+
+   // Setup Logging Directory
+   rimraf.sync("script_exec_outputs");
+   FileUtils.mkDirByPathSync("script_exec_outputs");
+ 
+
     // Assign workers to executed scripts
     let ts = Math.floor(Date.now() / 1000);
     for (let poolUser of this.poolConfig.poolUsers) {
@@ -572,9 +578,7 @@ export default class PoolCreateImpl {
 
     scriptFilePath = path.normalize(scriptFilePath);
 
-    rimraf.sync("script_exec_outputs");
-    FileUtils.mkDirByPathSync("script_exec_outputs");
-
+   
     if (process.platform != "win32") {
       cmd = `bash ${scriptFilePath}  ${scratchOrg.username}  ${hubOrgUserName} `;
     } else {


### PR DESCRIPTION
Scratch Org logging are written to script_exec_outputs. It was
incorrectly deleted during every execution of queue. This fixes the
incorrect clearing