### PR TITLE
Add retry capability to fetch installed packages in an org

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -705,6 +705,19 @@
         "axios": "^0.19.2"
       },
       "dependencies": {
+        "@salesforce/core": {
+          "version": "2.4.1",
+          "requires": {
+            "@salesforce/bunyan": "^2.0.0",
+            "@salesforce/kit": "^1.0.0",
+            "@salesforce/ts-types": "^1.0.0",
+            "@types/jsforce": "1.9.2",
+            "jsen": "0.6.6",
+            "jsforce": "1.9.3",
+            "jsonwebtoken": "8.5.0",
+            "sfdx-faye": "^1.0.9"
+          }
+        },
         "@salesforce/ts-types": {
           "version": "1.4.0",
           "requires": {
@@ -5659,6 +5672,19 @@
                 "ansi-regex": "^4.1.0"
               }
             }
+          }
+        },
+        "@salesforce/core": {
+          "version": "2.4.1",
+          "requires": {
+            "@salesforce/bunyan": "^2.0.0",
+            "@salesforce/kit": "^1.0.0",
+            "@salesforce/ts-types": "^1.0.0",
+            "@types/jsforce": "1.9.2",
+            "jsen": "0.6.6",
+            "jsforce": "1.9.3",
+            "jsonwebtoken": "8.5.0",
+            "sfdx-faye": "^1.0.9"
           }
         },
         "@salesforce/kit": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerkit",
-  "version": "2.0.10",
+  "version": "2.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -705,19 +705,6 @@
         "axios": "^0.19.2"
       },
       "dependencies": {
-        "@salesforce/core": {
-          "version": "2.4.1",
-          "requires": {
-            "@salesforce/bunyan": "^2.0.0",
-            "@salesforce/kit": "^1.0.0",
-            "@salesforce/ts-types": "^1.0.0",
-            "@types/jsforce": "1.9.2",
-            "jsen": "0.6.6",
-            "jsforce": "1.9.3",
-            "jsonwebtoken": "8.5.0",
-            "sfdx-faye": "^1.0.9"
-          }
-        },
         "@salesforce/ts-types": {
           "version": "1.4.0",
           "requires": {
@@ -5672,19 +5659,6 @@
                 "ansi-regex": "^4.1.0"
               }
             }
-          }
-        },
-        "@salesforce/core": {
-          "version": "2.4.1",
-          "requires": {
-            "@salesforce/bunyan": "^2.0.0",
-            "@salesforce/kit": "^1.0.0",
-            "@salesforce/ts-types": "^1.0.0",
-            "@types/jsforce": "1.9.2",
-            "jsen": "0.6.6",
-            "jsforce": "1.9.3",
-            "jsonwebtoken": "8.5.0",
-            "sfdx-faye": "^1.0.9"
           }
         },
         "@salesforce/kit": {

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.10",
+  "version": "2.0.12",
   "commands": {
     "sfpowerkit:auth:login": {
       "id": "sfpowerkit:auth:login",
@@ -2211,7 +2211,7 @@
             "ERROR",
             "FATAL"
           ],
-          "default": "warn"
+          "default": "info"
         },
         "targetdevhubusername": {
           "name": "targetdevhubusername",

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.11",
+  "version": "2.0.12",
   "commands": {
     "sfpowerkit:auth:login": {
       "id": "sfpowerkit:auth:login",
@@ -547,7 +547,8 @@
       "examples": [
         "$ sfdx sfpowerkit:pool:fetch -t core ",
         "$ sfdx sfpowerkit:pool:fetch -t core -v devhub",
-        "$ sfdx sfpowerkit:pool:fetch -t core -v devhub -m"
+        "$ sfdx sfpowerkit:pool:fetch -t core -v devhub -m",
+        "$ sfdx sfpowerkit:pool:fetch -t core -v devhub -s testuser@test.com"
       ],
       "flags": {
         "json": {
@@ -2218,7 +2219,7 @@
             "ERROR",
             "FATAL"
           ],
-          "default": "warn"
+          "default": "info"
         },
         "targetdevhubusername": {
           "name": "targetdevhubusername",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerkit",
   "description": "A Salesforce DX Plugin with multiple functionalities aimed at improving development and operational workflows",
-  "version": "2.0.10",
+  "version": "2.0.12",
   "author": {
     "name": "DXatScale",
     "email": "dxatscale@accenture.com"

--- a/src/commands/sfpowerkit/package/dependencies/install.ts
+++ b/src/commands/sfpowerkit/package/dependencies/install.ts
@@ -6,6 +6,8 @@ import { JsonArray, JsonMap } from "@salesforce/ts-types";
 import { SfdxProject } from "@salesforce/core";
 import { loadSFDX } from "../../../../sfdxnode/GetNodeWrapper";
 import { sfdx } from "../../../..//sfdxnode/parallel";
+import { SFPowerkit, LoggerLevel } from "../../../../sfpowerkit";
+let retry = require("async-retry");
 
 const packageIdPrefix = "0Ho";
 const packageVersionIdPrefix = "04t";
@@ -84,6 +86,25 @@ export default class Install extends SfdxCommand {
       required: false,
       description:
         "in a mono repo project, filter packageDirectories using path and install dependent packages only for the specified path"
+    }),
+    loglevel: flags.enum({
+      description: "logging level for this command invocation",
+      default: "info",
+      required: false,
+      options: [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal",
+        "TRACE",
+        "DEBUG",
+        "INFO",
+        "WARN",
+        "ERROR",
+        "FATAL"
+      ]
     })
   };
 
@@ -102,6 +123,8 @@ export default class Install extends SfdxCommand {
   public async run(): Promise<any> {
     const result = { installedPackages: {} };
 
+    SFPowerkit.setLogLevel(this.flags.loglevel, false);
+
     // this.org is guaranteed because requiresUsername=true, as opposed to supportsUsername
     const username = this.org.getUsername();
 
@@ -118,7 +141,16 @@ export default class Install extends SfdxCommand {
     }
 
     //Validate Packages  installed in the target org
-    let installedpackages = await this.getInstalledPackages(username);
+
+    let installedpackages = [];
+    try {
+      installedpackages = await this.getInstalledPackages(username);
+    } catch (error) {
+      console.log(
+        "Unable to retrieve the packages installed in the org, Proceeding",
+        LoggerLevel.WARN
+      );
+    }
 
     let individualpackage = this.flags.individualpackage;
 
@@ -425,29 +457,40 @@ export default class Install extends SfdxCommand {
       "SubscriberPackageVersion.PatchVersion, SubscriberPackageVersion.BuildNumber FROM InstalledSubscriberPackage " +
       "ORDER BY SubscriberPackageId";
     const conn = this.org.getConnection();
-    await conn.tooling.query(installedPackagesQuery).then(queryResult => {
-      const records = queryResult.records;
-      if (records && records.length > 0) {
-        this.ux.log(`Installed Packages in the org ${targetOrg}`);
-        const output = [];
-        records.forEach(record => {
-          packages.push(record["SubscriberPackageVersion"]["Id"]);
-          output.push({
-            name: record["SubscriberPackage"]["Name"],
-            package_version_name: record["SubscriberPackageVersion"]["Name"],
-            package_version_id: record["SubscriberPackageVersion"]["Id"],
-            versionNumber: `${record["SubscriberPackageVersion"]["MajorVersion"]}.${record["SubscriberPackageVersion"]["MinorVersion"]}.${record["SubscriberPackageVersion"]["PatchVersion"]}.${record["SubscriberPackageVersion"]["BuildNumber"]}`
+
+    return await retry(
+      async bail => {
+        SFPowerkit.log("QUERY:" + installedPackagesQuery, LoggerLevel.TRACE);
+
+        const results = (await conn.tooling.query(
+          installedPackagesQuery
+        )) as any;
+
+        const records = results.records;
+        if (records && records.length > 0) {
+          this.ux.log(`Installed Packages in the org ${targetOrg}`);
+          const output = [];
+          records.forEach(record => {
+            packages.push(record["SubscriberPackageVersion"]["Id"]);
+            output.push({
+              name: record["SubscriberPackage"]["Name"],
+              package_version_name: record["SubscriberPackageVersion"]["Name"],
+              package_version_id: record["SubscriberPackageVersion"]["Id"],
+              versionNumber: `${record["SubscriberPackageVersion"]["MajorVersion"]}.${record["SubscriberPackageVersion"]["MinorVersion"]}.${record["SubscriberPackageVersion"]["PatchVersion"]}.${record["SubscriberPackageVersion"]["BuildNumber"]}`
+            });
           });
-        });
-        this.ux.table(output, [
-          "name",
-          "package_version_name",
-          "package_version_id",
-          "versionNumber"
-        ]);
-      }
-    });
-    return packages;
+          this.ux.table(output, [
+            "name",
+            "package_version_name",
+            "package_version_id",
+            "versionNumber"
+          ]);
+
+          return packages;
+        }
+      },
+      { retries: 3, minTimeout: 3000 }
+    );
   }
   private parseKeyValueMapfromString(
     request: string,


### PR DESCRIPTION
Add retry capability while fetching the installed packages in an org. This query can be awfully slow, especially in a new scratchorg for some unknown reason, causing pipelines to fail. Hence add a retry and skip if still not able to figure out  the packages.