### PR TITLE
Enhancements to Scratch Org Pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,11 +1241,14 @@ Creates a pool of prebuilt scratchorgs, which can the be consumed by users or CI
 
 ```
 USAGE
-  $ sfdx sfpowerkit:pool:create -f <filepath> [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
+  $ sfdx sfpowerkit:pool:create -f <filepath> [-b <number>] [-v <string>] [--apiversion <string>] [--json] [--loglevel
+  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
-  -f, --configfilepath=configfilepath                                               (required) Relative Path to the pool configuration json file. The schema of the file could be found in
-                                                                                    the Wiki
+  -b, --batchsize=batchsize                                                         [default: 10] Number of scratch org to be created in a single batch
+
+  -f, --configfilepath=configfilepath                                               (required) Relative Path to the pool configuration json file. The schema of the file could
+                                                                                    be found in the Wiki
 
   -v, --targetdevhubusername=targetdevhubusername                                   username or alias for the dev hub org; overrides default dev hub org
 

--- a/messages/scratchorg_pool_create.json
+++ b/messages/scratchorg_pool_create.json
@@ -1,4 +1,5 @@
 {
   "commandDescription": "Creates a pool of prebuilt scratchorgs, which can the be consumed by users or CI",
-  "configFilePathDescription": "Relative Path to the pool configuration json file. The schema of the file could be found in the Wiki"
+  "configFilePathDescription": "Relative Path to the pool configuration json file. The schema of the file could be found in the Wiki",
+  "batchSizeDescription": "Number of scratch org to be created in a single batch"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -705,19 +705,6 @@
         "axios": "^0.19.2"
       },
       "dependencies": {
-        "@salesforce/core": {
-          "version": "2.4.1",
-          "requires": {
-            "@salesforce/bunyan": "^2.0.0",
-            "@salesforce/kit": "^1.0.0",
-            "@salesforce/ts-types": "^1.0.0",
-            "@types/jsforce": "1.9.2",
-            "jsen": "0.6.6",
-            "jsforce": "1.9.3",
-            "jsonwebtoken": "8.5.0",
-            "sfdx-faye": "^1.0.9"
-          }
-        },
         "@salesforce/ts-types": {
           "version": "1.4.0",
           "requires": {
@@ -5672,19 +5659,6 @@
                 "ansi-regex": "^4.1.0"
               }
             }
-          }
-        },
-        "@salesforce/core": {
-          "version": "2.4.1",
-          "requires": {
-            "@salesforce/bunyan": "^2.0.0",
-            "@salesforce/kit": "^1.0.0",
-            "@salesforce/ts-types": "^1.0.0",
-            "@types/jsforce": "1.9.2",
-            "jsen": "0.6.6",
-            "jsforce": "1.9.3",
-            "jsonwebtoken": "8.5.0",
-            "sfdx-faye": "^1.0.9"
           }
         },
         "@salesforce/kit": {

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -400,7 +400,7 @@
     "sfpowerkit:pool:create": {
       "id": "sfpowerkit:pool:create",
       "description": "Creates a pool of prebuilt scratchorgs, which can the be consumed by users or CI",
-      "usage": "<%= command.id %> -f <filepath> [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "usage": "<%= command.id %> -f <filepath> [-b <number>] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
       "pluginName": "sfpowerkit",
       "pluginType": "core",
       "aliases": [],
@@ -454,6 +454,13 @@
           "char": "f",
           "description": "Relative Path to the pool configuration json file. The schema of the file could be found in the Wiki",
           "required": true
+        },
+        "batchsize": {
+          "name": "batchsize",
+          "type": "option",
+          "char": "b",
+          "description": "Number of scratch org to be created in a single batch",
+          "required": false
         }
       },
       "args": []

--- a/schemas/pool/so_pool_config_tag_mode.json
+++ b/schemas/pool/so_pool_config_tag_mode.json
@@ -2,7 +2,6 @@
   "pool": {
     "expiry": 1,
     "config_file_path": "config/project-scratch-def.json",
-
     "tag": "sfpowerkit",
     "relax_ip_ranges": [
       {

--- a/src/commands/sfpowerkit/pool/create.ts
+++ b/src/commands/sfpowerkit/pool/create.ts
@@ -32,6 +32,12 @@ export default class Create extends SfdxCommand {
       description: messages.getMessage("configFilePathDescription"),
       required: true
     }),
+    batchsize: flags.number({
+      char: "b",
+      default: 10,
+      description: messages.getMessage("batchSizeDescription"),
+      required: false
+    }),
     loglevel: flags.enum({
       description: "logging level for this command invocation",
       default: "info",
@@ -69,7 +75,8 @@ export default class Create extends SfdxCommand {
       this.flags.configfilepath,
       this.hubOrg,
       this.flags.apiversion,
-      sfdx
+      sfdx,
+      this.flags.batchsize
     );
 
     try {

--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -11,10 +11,6 @@ import * as path from "path";
 import * as rimraf from "rimraf";
 import { SfdxApi } from "../../../sfdxnode/types";
 
-const limiter = new Bottleneck({
-  maxConcurrent: 10
-});
-
 export default class PoolCreateImpl {
   private hubConn: Connection;
 
@@ -25,20 +21,28 @@ export default class PoolCreateImpl {
   private limits;
   private scriptFileExists: boolean;
   private totalAllocated: number = 0;
-
-  private scriptExecutorWrappedForBottleneck = limiter.wrap(
-    this.scriptExecutor
-  );
-  private ipRangeRelaxerWrappedForBottleneck = limiter.wrap(
-    this.ipRangeRelaxer
-  );
+  private limiter;
+  private scriptExecutorWrappedForBottleneck;
+  private ipRangeRelaxerWrappedForBottleneck;
 
   public constructor(
     private poolconfigFilePath: string,
     private hubOrg: Org,
     private apiversion: string,
-    private sfdx: SfdxApi
-  ) {}
+    private sfdx: SfdxApi,
+    private batchSize: number
+  ) {
+    this.limiter = new Bottleneck({
+      maxConcurrent: batchSize
+    });
+
+    this.scriptExecutorWrappedForBottleneck = this.limiter.wrap(
+      this.scriptExecutor
+    );
+    this.ipRangeRelaxerWrappedForBottleneck = this.limiter.wrap(
+      this.ipRangeRelaxer
+    );
+  }
 
   public async poolScratchOrgs(): Promise<boolean> {
     let scriptExecPromises: Array<Promise<ScriptExecutionResult>> = new Array();
@@ -112,6 +116,7 @@ export default class PoolCreateImpl {
     );
 
     if (
+      !this.poolConfig.pool.relax_all_ip_ranges &&
       isNullOrUndefined(this.poolConfig.pool.relax_ip_ranges) &&
       !this.poolConfig.pool.user_mode
     ) {
@@ -154,7 +159,10 @@ export default class PoolCreateImpl {
       for (let scratchOrg of poolUser.scratchOrgs) {
         SFPowerkit.log(JSON.stringify(scratchOrg), LoggerLevel.DEBUG);
 
-        if (this.poolConfig.pool.relax_ip_ranges) {
+        if (
+          this.poolConfig.pool.relax_all_ip_ranges ||
+          this.poolConfig.pool.relax_ip_ranges
+        ) {
           let resultForIPRelaxation = this.ipRangeRelaxerWrappedForBottleneck(
             scratchOrg
           );
@@ -162,7 +170,10 @@ export default class PoolCreateImpl {
         }
 
         //Wait for scripts to finish execution
-        if (this.poolConfig.pool.relax_ip_ranges)
+        if (
+          this.poolConfig.pool.relax_all_ip_ranges ||
+          this.poolConfig.pool.relax_ip_ranges
+        )
           this.ipRangeExecResults = await Promise.all(ipRangeExecPromises);
 
         if (this.scriptFileExists) {
@@ -188,7 +199,10 @@ export default class PoolCreateImpl {
     }
 
     //Get IP Range results
-    if (!isNullOrUndefined(this.poolConfig.pool.relax_ip_ranges))
+    if (
+      this.poolConfig.pool.relax_ip_ranges ||
+      !isNullOrUndefined(this.poolConfig.pool.relax_ip_ranges)
+    )
       this.ipRangeExecResultsAsObject = this.arrayToObject(
         this.ipRangeExecResults,
         "username"
@@ -329,7 +343,7 @@ export default class PoolCreateImpl {
       poolUser.scratchOrgs = new Array<ScratchOrg>();
       for (let i = 0; i < poolUser.to_allocate; i++) {
         SFPowerkit.log(
-          `Creating Scratch  Org for ${count} of ${this.totalToBeAllocated}..`,
+          `Creating Scratch  Org  ${count} of ${this.totalToBeAllocated}..`,
           LoggerLevel.INFO
         );
         try {
@@ -385,13 +399,17 @@ export default class PoolCreateImpl {
           let activeScratchOrgRecordId = await ScratchOrgUtils.getActiveScratchOrgRecordIdGivenScratchOrg(
             this.hubOrg,
             this.apiversion,
-            scratchOrg.recordId
+            scratchOrg.orgId
           );
 
           await ScratchOrgUtils.deleteScratchOrg(
             this.hubOrg,
             this.apiversion,
             activeScratchOrgRecordId
+          );
+          SFPowerkit.log(
+            `Succesfully deleted scratchorg  ${scratchOrg.username}`,
+            LoggerLevel.TRACE
           );
         } catch (error) {
           SFPowerkit.log(
@@ -548,11 +566,22 @@ export default class PoolCreateImpl {
     const connection = await Connection.create({
       authInfo: await AuthInfo.create({ username: scratchOrg.username })
     });
-    return RelaxIPRangeImpl.setIp(
-      connection,
-      scratchOrg.username,
-      this.poolConfig.pool.relax_ip_ranges
-    );
+
+    if (this.poolConfig.pool.relax_all_ip_ranges) {
+      this.poolConfig.pool.relax_ip_ranges = [];
+      return RelaxIPRangeImpl.setIp(
+        connection,
+        scratchOrg.username,
+        this.poolConfig.pool.relax_ip_ranges,
+        this.poolConfig.pool.relax_all_ip_ranges
+      );
+    } else {
+      return RelaxIPRangeImpl.setIp(
+        connection,
+        scratchOrg.username,
+        this.poolConfig.pool.relax_ip_ranges
+      );
+    }
   }
 
   private async scriptExecutor(
@@ -562,7 +591,6 @@ export default class PoolCreateImpl {
   ): Promise<ScriptExecutionResult> {
     //executue using bash
     let cmd;
-    let logRestricter = 0;
 
     SFPowerkit.log(`Script File Path: ${scriptFilePath}`, LoggerLevel.TRACE);
 
@@ -581,15 +609,17 @@ export default class PoolCreateImpl {
     );
 
     SFPowerkit.log(
-      `Script Execution result written to script_exec_outputs/${scratchOrg.alias} `,
+      `Script Execution result is being written to script_exec_outputs/${scratchOrg.alias}.log, Please note this will take a significant time depending on the  script being executed`,
       LoggerLevel.INFO
     );
+
+    let fdr = fs.openSync(`script_exec_outputs/${scratchOrg.alias}.log`, "a");
 
     return new Promise((resolve, reject) => {
       let ls = exec(cmd, { cwd: process.cwd() }, (error, stdout, stderr) => {
         if (error) {
           SFPowerkit.log(
-            `failed to execute script for ${scratchOrg.username}`,
+            `Failed to execute script for ${scratchOrg.username}`,
             LoggerLevel.WARN
           );
           scratchOrg.isScriptExecuted = false;
@@ -605,13 +635,17 @@ export default class PoolCreateImpl {
 
         if (stderr) {
           SFPowerkit.log(stderr, LoggerLevel.DEBUG);
-          fs.appendFileSync(`script_exec_outputs/${scratchOrg.alias}`, stderr);
+          fs.appendFileSync(
+            `script_exec_outputs/${scratchOrg.alias}.log`,
+            stderr
+          );
         }
 
         scratchOrg.isScriptExecuted = true;
 
         if (
-          this.poolConfig.pool.relax_ip_ranges &&
+          (this.poolConfig.pool.relax_all_ip_ranges ||
+            this.poolConfig.pool.relax_ip_ranges) &&
           !this.ipRangeExecResultsAsObject[scratchOrg.username]["success"]
         )
           scratchOrg.isScriptExecuted = false;
@@ -627,6 +661,7 @@ export default class PoolCreateImpl {
           ).then(
             (result: boolean) => {
               scratchOrg.isScriptExecuted = true;
+              fs.closeSync(fdr);
               resolve({
                 isSuccess: true,
                 message: "Successfuly set the scratch org record in Pool",
@@ -635,6 +670,7 @@ export default class PoolCreateImpl {
               });
             },
             (reason: any) => {
+              fs.closeSync(fdr);
               scratchOrg.isScriptExecuted = false;
               resolve({
                 isSuccess: false,
@@ -648,15 +684,7 @@ export default class PoolCreateImpl {
       });
 
       ls.stdout.on("data", function(data) {
-        fs.appendFileSync(`script_exec_outputs/${scratchOrg.alias}`, data);
-        //Print only processing if there is more than 5 logs, Restrict Verbose scripts like sfpowerkit package dependencies install
-        if (logRestricter % 10 == 0) {
-          SFPowerkit.log(
-            `Processing for ${scratchOrg.alias} with ${scratchOrg.username}: IN_PROGRESS....`,
-            LoggerLevel.INFO
-          );
-        }
-        logRestricter++;
+        fs.appendFileSync(`script_exec_outputs/${scratchOrg.alias}.log`, data);
       });
     });
   }
@@ -679,6 +707,7 @@ export interface Pool {
   script_file_path?: string;
   tag: string;
   user_mode: boolean;
+  relax_all_ip_ranges: true;
   relax_ip_ranges: IpRanges[];
   max_allocation: number;
 }

--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -707,7 +707,7 @@ export interface Pool {
   script_file_path?: string;
   tag: string;
   user_mode: boolean;
-  relax_all_ip_ranges: true;
+  relax_all_ip_ranges: boolean;
   relax_ip_ranges: IpRanges[];
   max_allocation: number;
 }


### PR DESCRIPTION
- Support for Batch Size
  Batch Size of the pool creation is now configurable by basis of an additional flag, rather than the hardcoded value of 10

- Support for relaxing all ip ranges
  The schema now supports an addition relax_all_ip_ranges, which can relax all ip ranges in the created scratch org, mainly for non CI users

- Fixes to Logging
   Streamlined logging, now there would be no script execution log in the console output. All scripts logs will be written directly the log files

- Bugfix Deletion of ScratchOrg
  ScratchOrg that had script execution failures where not returned to the pool.