### PR TITLE
feat: Dependency version list feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ sfdx plugins:link
     - [`sfpowerkit:project:datamodel:diff [BETA]`](#sfpowerkitprojectdatamodeldiff-beta)
   - [Unlocked Package Related Functionalities](#unlocked-package-related-functionalities)
     - [`sfpowerkit:package:dependencies:install`](#sfpowerkitpackagedependenciesinstall)
+    - [`sfpowerkit:package:dependencies:versionlist`](#sfpowerkitpackagedependenciesversionlist)
     - [`sfpowerkit:package:version:codecoverage`](#sfpowerkitpackageversioncodecoverage)
     - [`sfpowerkit:package:version:info`](#sfpowerkitpackageversioninfo)
     - [`sfpowerkit:package:valid`](#sfpowerkitpackagevalid)
@@ -511,6 +512,37 @@ EXAMPLE
 ```
 
 _See code: [src\commands\sfpowerkit\package\dependencies\install.ts](https://github.com/Accenture/sfpowerkit/blob/main/src/commands/sfpowerkit/package/dependencies/install.ts)_
+
+### `sfpowerkit:package:dependencies:versionlist`
+
+Fetch dependencies version details of a package
+
+```
+USAGE
+  $ sfdx sfpowerkit:package:dependencies:versionlist [-p <array>] [-s] [--usedependencyvalidatedpackages] [-v <string>] [--apiversion <string>] [--json] [--loglevel
+  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
+
+OPTIONS
+  -p, --filterpaths=filterpaths                                                     filter packageDirectories using path to get dependent packages details only for the
+                                                                                    specified path
+
+  -s, --updateproject                                                               update the sfdx-project.json with result
+
+  -v, --targetdevhubusername=targetdevhubusername                                   username or alias for the dev hub org; overrides default dev hub org
+
+  --apiversion=apiversion                                                           override the api version used for api requests made by this command
+
+  --json                                                                            format output as json
+
+  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for this command invocation
+
+  --usedependencyvalidatedpackages                                                  use dependency validated packages that matches the version number schema provide
+
+EXAMPLES
+  $ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s src/dreamhouse
+  $ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub --updateproject
+  $ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s --usedependencyvalidatedpackages
+```
 
 ### `sfpowerkit:package:version:codecoverage`
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ sfdx plugins:link
     - [`sfpowerkit:project:datamodel:diff [BETA]`](#sfpowerkitprojectdatamodeldiff-beta)
   - [Unlocked Package Related Functionalities](#unlocked-package-related-functionalities)
     - [`sfpowerkit:package:dependencies:install`](#sfpowerkitpackagedependenciesinstall)
-    - [`sfpowerkit:package:dependencies:versionlist`](#sfpowerkitpackagedependenciesversionlist)
+    - [`sfpowerkit:package:dependencies:list`](#sfpowerkitpackagedependencieslist)
     - [`sfpowerkit:package:version:codecoverage`](#sfpowerkitpackageversioncodecoverage)
     - [`sfpowerkit:package:version:info`](#sfpowerkitpackageversioninfo)
     - [`sfpowerkit:package:valid`](#sfpowerkitpackagevalid)
@@ -513,13 +513,13 @@ EXAMPLE
 
 _See code: [src\commands\sfpowerkit\package\dependencies\install.ts](https://github.com/Accenture/sfpowerkit/blob/main/src/commands/sfpowerkit/package/dependencies/install.ts)_
 
-### `sfpowerkit:package:dependencies:versionlist`
+### `sfpowerkit:package:dependencies:list`
 
 Fetch dependencies version details of a package
 
 ```
 USAGE
-  $ sfdx sfpowerkit:package:dependencies:versionlist [-p <array>] [-s] [--usedependencyvalidatedpackages] [-v <string>] [--apiversion <string>] [--json] [--loglevel
+  $ sfdx sfpowerkit:package:dependencies:list [-p <array>] [-s] [--usedependencyvalidatedpackages] [-v <string>] [--apiversion <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -539,9 +539,9 @@ OPTIONS
   --usedependencyvalidatedpackages                                                  use dependency validated packages that matches the version number schema provide
 
 EXAMPLES
-  $ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s src/dreamhouse
-  $ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub --updateproject
-  $ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s --usedependencyvalidatedpackages
+  $ sfdx sfpowerkit:package:dependencies:list -v MyDevHub -s src/dreamhouse
+  $ sfdx sfpowerkit:package:dependencies:list -v MyDevHub --updateproject
+  $ sfdx sfpowerkit:package:dependencies:list -v MyDevHub -s --usedependencyvalidatedpackages
 ```
 
 ### `sfpowerkit:package:version:codecoverage`

--- a/messages/dependency_versionlist.json
+++ b/messages/dependency_versionlist.json
@@ -1,0 +1,6 @@
+{
+  "commandDescription": "Fetch dependencies version details of a package",
+  "usedependencyvalidatedpackagesDescription": "use dependency validated packages that matches the version number schema provide",
+  "updateprojectDescription": "update the sfdx-project.json with result",
+  "filterpathsDescription": "filter packageDirectories using path to get dependent packages details only for the specified path"
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerkit",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4449,6 +4449,55 @@
         "xmldom-sfdx-encoding": "^0.1.30"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.16.0",
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "@oclif/errors": {
+              "version": "1.3.3",
+              "requires": {
+                "fs-extra": "^9.0.1",
+                "indent-string": "^4.0.0",
+                "strip-ansi": "^6.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "fs-extra": {
+              "version": "9.0.1",
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^1.0.0"
+              }
+            },
+            "jsonfile": {
+              "version": "6.0.1",
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^1.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.0"
+            },
+            "universalify": {
+              "version": "1.0.0"
+            }
+          }
+        },
         "@oclif/plugin-help": {
           "version": "2.2.3",
           "requires": {
@@ -4460,6 +4509,44 @@
             "strip-ansi": "^5.0.0",
             "widest-line": "^2.0.1",
             "wrap-ansi": "^4.0.0"
+          }
+        },
+        "@salesforce/core": {
+          "version": "2.11.0",
+          "requires": {
+            "@salesforce/bunyan": "^2.0.0",
+            "@salesforce/kit": "^1.2.2",
+            "@salesforce/schemas": "^1.0.1",
+            "@salesforce/ts-types": "^1.0.0",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/jsforce": "1.9.2",
+            "debug": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jsen": "0.6.6",
+            "jsforce": "1.9.3",
+            "jsonwebtoken": "8.5.0",
+            "mkdirp": "1.0.4",
+            "sfdx-faye": "^1.0.9"
+          },
+          "dependencies": {
+            "jsonwebtoken": {
+              "version": "8.5.0",
+              "requires": {
+                "jws": "^3.2.1",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^5.6.0"
+              }
+            },
+            "mkdirp": {
+              "version": "1.0.4"
+            }
           }
         },
         "@salesforce/kit": {

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -2324,17 +2324,17 @@
       },
       "args": []
     },
-    "sfpowerkit:package:dependencies:versionlist": {
-      "id": "sfpowerkit:package:dependencies:versionlist",
+    "sfpowerkit:package:dependencies:list": {
+      "id": "sfpowerkit:package:dependencies:list",
       "description": "Fetch dependencies version details of a package",
       "usage": "<%= command.id %> [-p <array>] [-s] [--usedependencyvalidatedpackages] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
       "pluginName": "sfpowerkit",
       "pluginType": "core",
       "aliases": [],
       "examples": [
-        "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s src/dreamhouse",
-        "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub --updateproject",
-        "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s --usedependencyvalidatedpackages"
+        "$ sfdx sfpowerkit:package:dependencies:list -v MyDevHub -s src/dreamhouse",
+        "$ sfdx sfpowerkit:package:dependencies:list -v MyDevHub --updateproject",
+        "$ sfdx sfpowerkit:package:dependencies:list -v MyDevHub -s --usedependencyvalidatedpackages"
       ],
       "flags": {
         "json": {

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.3",
+  "version": "2.2.4",
   "commands": {
     "sfpowerkit:auth:login": {
       "id": "sfpowerkit:auth:login",
@@ -2320,6 +2320,83 @@
           "char": "f",
           "description": "in a mono repo project, filter packageDirectories using path and install dependent packages only for the specified path",
           "required": false
+        }
+      },
+      "args": []
+    },
+    "sfpowerkit:package:dependencies:versionlist": {
+      "id": "sfpowerkit:package:dependencies:versionlist",
+      "description": "Fetch dependencies version details of a package",
+      "usage": "<%= command.id %> [-p <array>] [-s] [--usedependencyvalidatedpackages] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+      "pluginName": "sfpowerkit",
+      "pluginType": "core",
+      "aliases": [],
+      "examples": [
+        "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s src/dreamhouse",
+        "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub --updateproject",
+        "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s --usedependencyvalidatedpackages"
+      ],
+      "flags": {
+        "json": {
+          "name": "json",
+          "type": "boolean",
+          "description": "format output as json",
+          "allowNo": false
+        },
+        "loglevel": {
+          "name": "loglevel",
+          "type": "option",
+          "description": "logging level for this command invocation",
+          "required": false,
+          "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+          "options": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal",
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ],
+          "default": "warn"
+        },
+        "targetdevhubusername": {
+          "name": "targetdevhubusername",
+          "type": "option",
+          "char": "v",
+          "description": "username or alias for the dev hub org; overrides default dev hub org"
+        },
+        "apiversion": {
+          "name": "apiversion",
+          "type": "option",
+          "description": "override the api version used for api requests made by this command"
+        },
+        "filterpaths": {
+          "name": "filterpaths",
+          "type": "option",
+          "char": "p",
+          "description": "filter packageDirectories using path to get dependent packages details only for the specified path",
+          "required": false
+        },
+        "updateproject": {
+          "name": "updateproject",
+          "type": "boolean",
+          "char": "s",
+          "description": "update the sfdx-project.json with result",
+          "required": false,
+          "allowNo": false
+        },
+        "usedependencyvalidatedpackages": {
+          "name": "usedependencyvalidatedpackages",
+          "type": "boolean",
+          "description": "use dependency validated packages that matches the version number schema provide",
+          "required": false,
+          "allowNo": false
         }
       },
       "args": []

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerkit",
   "description": "A Salesforce DX Plugin with multiple functionalities aimed at improving development and operational workflows",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "author": {
     "name": "DXatScale",
     "email": "dxatscale@accenture.com"

--- a/src/commands/sfpowerkit/package/dependencies/list.ts
+++ b/src/commands/sfpowerkit/package/dependencies/list.ts
@@ -72,7 +72,7 @@ export default class List extends SfdxCommand {
           packageDirectory.dependencies[0] !== undefined
         ) {
           this.ux.log(
-            `\nPackage dependencies found for package directory ${packageDirectory.path}`
+            `\nPackage dependencies for the given package directory ${packageDirectory.path}`
           );
           for (let dependency of packageDirectory.dependencies) {
             if (
@@ -148,7 +148,11 @@ export default class List extends SfdxCommand {
 
       if (resultPackageId.size === 0) {
         // Query returned no result
-        const errorMessage = `Unable to find SubscriberPackageVersionId for dependent package ${dependency.package}`;
+        const errorMessage = `Unable to find package ${
+          dependency.package
+        } of version ${
+          dependency.versionNumber
+        } in devhub ${this.hubOrg.getUsername()}. Are you sure it is created yet?`;
         throw new core.SfdxError(errorMessage);
       } else {
         let versionId = resultPackageId.records[0].SubscriberPackageVersionId;

--- a/src/commands/sfpowerkit/package/dependencies/list.ts
+++ b/src/commands/sfpowerkit/package/dependencies/list.ts
@@ -15,13 +15,13 @@ const messages = core.Messages.loadMessages(
   "dependency_versionlist"
 );
 
-export default class Versionlist extends SfdxCommand {
+export default class List extends SfdxCommand {
   public static description = messages.getMessage("commandDescription");
 
   public static examples = [
-    "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s src/dreamhouse",
-    "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub --updateproject",
-    "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s --usedependencyvalidatedpackages",
+    "$ sfdx sfpowerkit:package:dependencies:list -v MyDevHub -s src/dreamhouse",
+    "$ sfdx sfpowerkit:package:dependencies:list -v MyDevHub --updateproject",
+    "$ sfdx sfpowerkit:package:dependencies:list -v MyDevHub -s --usedependencyvalidatedpackages",
   ];
 
   protected static flagsConfig = {

--- a/src/commands/sfpowerkit/package/dependencies/versionlist.ts
+++ b/src/commands/sfpowerkit/package/dependencies/versionlist.ts
@@ -1,0 +1,161 @@
+import { core, flags, SfdxCommand } from "@salesforce/command";
+import { Connection } from "@salesforce/core";
+import * as fs from "fs-extra";
+
+const packageIdPrefix = "0Ho";
+const packageVersionIdPrefix = "04t";
+
+// Initialize Messages with the current plugin directory
+core.Messages.importMessagesDirectory(__dirname);
+
+// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
+// or any library that is using the messages framework can also be loaded this way.
+const messages = core.Messages.loadMessages(
+  "sfpowerkit",
+  "dependency_versionlist"
+);
+
+export default class Versionlist extends SfdxCommand {
+  public static description = messages.getMessage("commandDescription");
+
+  public static examples = [
+    "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s src/dreamhouse",
+    "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub --updateproject",
+    "$ sfdx sfpowerkit:package:dependencies:versionlist -v MyDevHub -s --usedependencyvalidatedpackages",
+  ];
+
+  protected static flagsConfig = {
+    filterpaths: flags.array({
+      char: "p",
+      required: false,
+      description: messages.getMessage("filterpathsDescription"),
+    }),
+    updateproject: flags.boolean({
+      char: "s",
+      required: false,
+      description: messages.getMessage("updateprojectDescription"),
+    }),
+    usedependencyvalidatedpackages: flags.boolean({
+      required: false,
+      description: messages.getMessage(
+        "usedependencyvalidatedpackagesDescription"
+      ),
+    }),
+  };
+
+  // Comment this out if your command does not require a hub org username
+  protected static requiresDevhubUsername = true;
+
+  // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
+  protected static requiresProject = true;
+
+  public async run(): Promise<any> {
+    const conn = this.hubOrg.getConnection();
+    let projectConfig = JSON.parse(
+      fs.readFileSync("sfdx-project.json", "utf8")
+    );
+
+    let filterpaths = [];
+    if (this.flags.filterpaths) {
+      this.flags.filterpaths.forEach((path) => {
+        filterpaths.push(path.split("\\").join("/"));
+      });
+    }
+
+    for (let packageDirectory of projectConfig.packageDirectories) {
+      if (
+        filterpaths.length == 0 ||
+        filterpaths.includes(packageDirectory.path)
+      ) {
+        if (
+          packageDirectory.dependencies &&
+          packageDirectory.dependencies[0] !== undefined
+        ) {
+          this.ux.log(
+            `\nPackage dependencies found for package directory ${packageDirectory.path}`
+          );
+          for (let dependency of packageDirectory.dependencies) {
+            if (
+              projectConfig.packageAliases[dependency.package] !== "undefined"
+            ) {
+              await this.getPackageVersionDetails(
+                conn,
+                dependency,
+                projectConfig.packageAliases
+              );
+
+              this.ux.log(
+                `    ${dependency.versionId} : ${dependency.package}${
+                  dependency.versionNumber === undefined
+                    ? ""
+                    : " " + dependency.versionNumber
+                }`
+              );
+            }
+          }
+        } else {
+          this.ux.log(
+            `\nNo dependencies found for package directory ${packageDirectory.path}`
+          );
+        }
+      }
+    }
+
+    if (this.flags.updateproject) {
+      fs.writeFileSync(
+        "sfdx-project.json",
+        JSON.stringify(projectConfig, null, 2)
+      );
+    }
+
+    return projectConfig;
+  }
+
+  private async getPackageVersionDetails(
+    conn: Connection,
+    dependency: any,
+    packageAliases: any
+  ) {
+    let packageId = packageAliases[dependency.package];
+    if (packageId.startsWith(packageVersionIdPrefix)) {
+      // Package2VersionId is set directly
+      dependency["versionId"] = packageId;
+    } else if (packageId.startsWith(packageIdPrefix)) {
+      if (!dependency.versionNumber) {
+        throw new core.SfdxError(
+          `version number is mandatory for ${dependency.package}`
+        );
+      }
+
+      // Get Package version id from package + versionNumber
+      const vers = dependency.versionNumber.split(".");
+      let query =
+        "Select SubscriberPackageVersionId, IsPasswordProtected, IsReleased, MajorVersion, MinorVersion, PatchVersion,BuildNumber ";
+      query += "from Package2Version ";
+      query += `where Package2Id='${packageId}' and MajorVersion=${vers[0]} and MinorVersion=${vers[1]} and PatchVersion=${vers[2]} `;
+
+      // If Build Number isn't set to LATEST, look for the exact Package Version
+      if (vers[3] !== "LATEST") {
+        query += `and BuildNumber=${vers[3]} `;
+      } else if (this.flags.usedependencyvalidatedpackages) {
+        query += `and ValidationSkipped = false `;
+      }
+
+      query += "ORDER BY BuildNumber DESC, createddate DESC Limit 1";
+
+      // Query DevHub to get the expected Package2Version
+      const resultPackageId = (await conn.tooling.query(query)) as any;
+
+      if (resultPackageId.size === 0) {
+        // Query returned no result
+        const errorMessage = `Unable to find SubscriberPackageVersionId for dependent package ${dependency.package}`;
+        throw new core.SfdxError(errorMessage);
+      } else {
+        let versionId = resultPackageId.records[0].SubscriberPackageVersionId;
+        let versionNumber = `${resultPackageId.records[0].MajorVersion}.${resultPackageId.records[0].MinorVersion}.${resultPackageId.records[0].PatchVersion}.${resultPackageId.records[0].BuildNumber}`;
+        dependency["versionId"] = versionId;
+        dependency["versionNumber"] = versionNumber;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Often when working with packages, it is quite common to use .next to aid in package versions. However it is hard to understand, against which dependency this package was created ( unless you have a real strong versioning strategy in play). This command resolves next to the exact version of the dependent packages and updates the .sfdx project json. 

This solves the issues as logged in https://github.com/forcedotcom/cli/issues/593