### PR TITLE
Use CaseInsensitiveInputStream for Apex parsing

### DIFF
--- a/src/commands/sfpowerkit/source/apextest/list.ts
+++ b/src/commands/sfpowerkit/source/apextest/list.ts
@@ -1,5 +1,5 @@
 import { AnyJson } from "@salesforce/ts-types";
-import fs from "fs-extra";
+import { existsSync } from 'fs';
 import { core, flags, SfdxCommand } from "@salesforce/command";
 import { SFPowerkit, LoggerLevel } from "../../../../sfpowerkit";
 import { SfdxError } from "@salesforce/core";
@@ -61,7 +61,7 @@ export default class List extends SfdxCommand {
     SFPowerkit.setLogLevel(this.flags.loglevel, this.flags.json);
 
     //set apex class directory
-    if (!fs.existsSync(this.flags.path)) {
+    if (!existsSync(this.flags.path)) {
       throw new SfdxError(
         `path ${this.flags.path} does not exist. you must provide a valid path.`
       );


### PR DESCRIPTION
This is a fix for an issue @aly76 mentioned at https://github.com/nawforce/apex-parser/issues/3. 

The problem you are having is that Apex being a case insensitive language needs to use a special input stream for ANTLR. In the PR I have swapped the input stream and removed the workarounds. I have tested the this against a few thousand Apex files without error. 

While I was testing I had a problem with the fs.existsSync call in list.ts, fs was undefined. I tweaked the code to workaround this but not really sure what my problem was so you may not want that change. 