### PR TITLE
Make org:manifest:build --quickFilter function correctly

### DIFF
--- a/src/commands/sfpowerkit/org/manifest/build.ts
+++ b/src/commands/sfpowerkit/org/manifest/build.ts
@@ -3,7 +3,7 @@ import { Messages } from "@salesforce/core";
 import { AnyJson } from "@salesforce/ts-types";
 import {
   BuildConfig,
-  Packagexml
+  Packagexml,
 } from "../../../../impl/metadata/packageBuilder";
 
 // Initialize Messages with the current plugin directory
@@ -21,10 +21,10 @@ export default class Build extends SfdxCommand {
     <?xml version="1.0" encoding="UTF-8"?>
     <Package xmlns="http://soap.sforce.com/2006/04/metadata">...</Package>
     `,
-    `$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -q 'ApexClass, CustomObject, Report' 
+    `$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -q 'ApexClass, CustomObject:Account, Report'
     <?xml version="1.0" encoding="UTF-8"?>
     <Package xmlns="http://soap.sforce.com/2006/04/metadata">...</Package>
-    `
+    `,
   ];
 
   public static args = [{ name: "file" }];
@@ -32,20 +32,20 @@ export default class Build extends SfdxCommand {
   protected static flagsConfig = {
     quickfilter: flags.string({
       char: "q",
-      description: messages.getMessage("quickfilterFlagDescription")
+      description: messages.getMessage("quickfilterFlagDescription"),
     }),
     excludemanaged: flags.boolean({
       char: "x",
-      description: messages.getMessage("excludeManagedFlagDescription")
+      description: messages.getMessage("excludeManagedFlagDescription"),
     }),
     includechilds: flags.boolean({
       char: "c",
-      description: messages.getMessage("includeChildsFlagDescription")
+      description: messages.getMessage("includeChildsFlagDescription"),
     }),
     outputfile: flags.filepath({
       char: "o",
-      description: messages.getMessage("outputFileFlagDescription")
-    })
+      description: messages.getMessage("outputFileFlagDescription"),
+    }),
   };
 
   // Comment this out if your command does not require an org username

--- a/src/impl/metadata/packageBuilder.ts
+++ b/src/impl/metadata/packageBuilder.ts
@@ -168,7 +168,7 @@ export class Packagexml {
     for await (const object of describe.metadataObjects) {
       if (
         this.configs.quickFilters.length !== 0 &&
-        !this.configs.quickFilters.includes(object.xmlName)
+        this.configs.quickFilters.includes(object.xmlName)
       ) {
         continue;
       }
@@ -227,7 +227,7 @@ export class Packagexml {
     mdtypes.forEach((mdtype) => {
       if (
         this.configs.quickFilters.length === 0 ||
-        this.configs.quickFilters.includes(mdtype)
+        !this.configs.quickFilters.includes(mdtype)
       ) {
         packageJson.types.push({
           name: mdtype,
@@ -317,6 +317,14 @@ export class Packagexml {
           }
           unfolderedObjectItems.forEach((metadataEntries) => {
             if (metadataEntries) {
+              if (
+                this.configs.quickFilters.length !== 0 &&
+                this.configs.quickFilters.includes(
+                  metadataEntries.type + ":" + metadataEntries.fullName
+                )
+              ) {
+                return;
+              }
               this.addMember(metadataEntries.type, metadataEntries);
               this.result.push(metadataEntries);
             } else {


### PR DESCRIPTION
Quick Filters were excluding all metadata due to incorrectly applied filtering. Needed to correctly manage exclusion rules.

Added an exclusion at the per-member level so you could exclude an individual member, using the `type:membername` pattern used elsewhere in SFDX and not just an entire type, `force:source:deploy -m` as an example of specific member reference style.