### PR TITLE
Fix Error Logs not written while creating ScratchOrg Pools

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerkit",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.2",
+  "version": "2.4.3",
   "commands": {
     "sfpowerkit:auth:login": {
       "id": "sfpowerkit:auth:login",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerkit",
   "description": "A Salesforce DX Plugin with multiple functionalities aimed at improving development and operational workflows",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": {
     "name": "DXatScale",
     "email": "dxatscale@accenture.com"

--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -33,7 +33,7 @@ export default class PoolCreateImpl {
     private batchSize: number
   ) {
     this.limiter = new Bottleneck({
-      maxConcurrent: batchSize
+      maxConcurrent: batchSize,
     });
 
     this.scriptExecutorWrappedForBottleneck = this.limiter.wrap(
@@ -190,7 +190,7 @@ export default class PoolCreateImpl {
             {
               Id: scratchOrg.recordId,
               Pooltag__c: this.poolConfig.pool.tag,
-              Password__c: scratchOrg.password
+              Password__c: scratchOrg.password,
             },
             this.hubOrg
           );
@@ -266,7 +266,7 @@ export default class PoolCreateImpl {
       max_allocation: this.poolConfig.pool.max_allocation,
       is_build_pooluser: false,
       expiry: this.poolConfig.pool.expiry,
-      priority: 1
+      priority: 1,
     };
     //Add a single user
     this.poolConfig.poolUsers = [];
@@ -305,7 +305,7 @@ export default class PoolCreateImpl {
       scratchOrgsResult.records = scratchOrgsResult.records.sort();
 
       let scratchOrgsRecordAsMapByUser = scratchOrgsResult.records.reduce(
-        function(obj, v) {
+        function (obj, v) {
           obj[v.SignupEmail] = (obj[v.SignupEmail] || 0) + 1;
           return obj;
         },
@@ -473,7 +473,7 @@ export default class PoolCreateImpl {
     let totalMaxOrgRequired: number = 0,
       totalMinOrgRequired: number = 0;
 
-    poolUsers.forEach(pooluser => {
+    poolUsers.forEach((pooluser) => {
       SFPowerkit.log(pooluser, LoggerLevel.TRACE);
       pooluser.to_allocate = 0;
 
@@ -502,7 +502,7 @@ export default class PoolCreateImpl {
 
     if (totalMaxOrgRequired <= remainingScratchOrgs) {
       // Satisfy max. allocate max
-      poolUsers.forEach(pooluser => {
+      poolUsers.forEach((pooluser) => {
         pooluser.to_allocate = pooluser.to_satisfy_max;
         totalToBeAllocated += pooluser.to_satisfy_max;
       });
@@ -510,7 +510,7 @@ export default class PoolCreateImpl {
       // Satisfy min
       //First allocate minimum to everyone
 
-      poolUsers.forEach(pooluser => {
+      poolUsers.forEach((pooluser) => {
         pooluser.to_allocate = pooluser.to_satisfy_min;
         totalToBeAllocated += pooluser.to_satisfy_min;
       });
@@ -520,7 +520,7 @@ export default class PoolCreateImpl {
       if (leftOver > 0) {
         //Allocate LeftOver in a round robin model
         while (leftOver >= 0) {
-          poolUsers.forEach(pooluser => {
+          poolUsers.forEach((pooluser) => {
             if (leftOver == 0) return;
             if (
               pooluser.current_allocation + pooluser.to_allocate <
@@ -538,7 +538,7 @@ export default class PoolCreateImpl {
 
       //Allocate LeftOver in a round robin model
       while (leftOver >= 0) {
-        poolUsers.forEach(pooluser => {
+        poolUsers.forEach((pooluser) => {
           if (
             pooluser.current_allocation + pooluser.to_allocate <
             pooluser.to_satisfy_max
@@ -564,7 +564,7 @@ export default class PoolCreateImpl {
       LoggerLevel.INFO
     );
     const connection = await Connection.create({
-      authInfo: await AuthInfo.create({ username: scratchOrg.username })
+      authInfo: await AuthInfo.create({ username: scratchOrg.username }),
     });
 
     if (this.poolConfig.pool.relax_all_ip_ranges) {
@@ -628,17 +628,9 @@ export default class PoolCreateImpl {
             isSuccess: false,
             message: error.message,
             scratchOrgUsername: scratchOrg.username,
-            status: "failure"
+            status: "failure",
           });
           return;
-        }
-
-        if (stderr) {
-          SFPowerkit.log(stderr, LoggerLevel.DEBUG);
-          fs.appendFileSync(
-            `script_exec_outputs/${scratchOrg.alias}.log`,
-            stderr
-          );
         }
 
         scratchOrg.isScriptExecuted = true;
@@ -659,7 +651,7 @@ export default class PoolCreateImpl {
             {
               Id: scratchOrg.recordId,
               Pooltag__c: this.poolConfig.pool.tag,
-              Password__c: scratchOrg.password
+              Password__c: scratchOrg.password,
             },
             this.hubOrg
           ).then(
@@ -670,7 +662,7 @@ export default class PoolCreateImpl {
                 isSuccess: true,
                 message: "Successfuly set the scratch org record in Pool",
                 scratchOrgUsername: scratchOrg.username,
-                status: "success"
+                status: "success",
               });
             },
             (reason: any) => {
@@ -680,14 +672,18 @@ export default class PoolCreateImpl {
                 isSuccess: false,
                 message: "Unable to set the scratch org record in Pool",
                 scratchOrgUsername: scratchOrg.username,
-                status: "failure"
+                status: "failure",
               });
             }
           );
         }
       });
 
-      ls.stdout.on("data", function(data) {
+      ls.stderr.on("data", function (data) {
+        fs.appendFileSync(`script_exec_outputs/${scratchOrg.alias}.log`, data);
+      });
+
+      ls.stdout.on("data", function (data) {
         fs.appendFileSync(`script_exec_outputs/${scratchOrg.alias}.log`, data);
       });
     });


### PR DESCRIPTION
When scratch orgs fail due to an error in the poooling script,
logs are not written to the logfile.

Fixed by moving the stderror stream out from the call back

Fixes #385 