### PR TITLE
Improve sfpowerkit:org:manifest:build by allowing separate [in|ex]clude filters

### DIFF
--- a/messages/package_build.json
+++ b/messages/package_build.json
@@ -1,6 +1,8 @@
 {
   "commandDescription": "Generate a complete manifest of all the metadata from the specified org. Once the manifest is generated use source:retrieve or mdapi:retrieve to retrieve the metadata.",
-  "quickfilterFlagDescription": "comma separated values  of metadata type, member or file names to be excluded while building the manifest",
+  "quickfilterFlagDescription": "comma separated values of metadata type, member or file names to be excluded while building the manifest (deprecated)",
+  "excludefilterFlagDescription": "comma separated values of metadata type, member or file names to be excluded while building the manifest",
+  "includefilterFlagDescription": "comma separated values of metadata type, member or file names to be included while building the manifest",
   "excludeManagedFlagDescription": "exclude managed packages components from the manifest",
   "outputFileFlagDescription": "The output path where the manifest file will be created",
   "includeChildsFlagDescription": "Set to true to include child Metadata in the generated package.xml."

--- a/src/commands/sfpowerkit/org/manifest/build.ts
+++ b/src/commands/sfpowerkit/org/manifest/build.ts
@@ -18,8 +18,8 @@ export default class Build extends SfdxCommand {
 
   public static examples = [
     `$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml`,
-    `$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -q 'ApexClass,CustomObject,Report'`,
-    `$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -q 'ApexClass:sampleclass,CustomObject:Account'`,
+    `$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -e 'ApexClass,CustomObject,Report'`,
+    `$ sfdx sfpowerkit:org:manifest:build --targetusername myOrg@example.com -o package.xml -i 'ApexClass:sampleclass,CustomObject:Account'`,
   ];
 
   public static args = [{ name: "file" }];
@@ -28,6 +28,14 @@ export default class Build extends SfdxCommand {
     quickfilter: flags.string({
       char: "q",
       description: messages.getMessage("quickfilterFlagDescription"),
+    }),
+    excludefilter: flags.string({
+      char: "e",
+      description: messages.getMessage("excludefilterFlagDescription"),
+    }),
+    includefilter: flags.string({
+      char: "i",
+      description: messages.getMessage("includefilterFlagDescription"),
     }),
     excludemanaged: flags.boolean({
       char: "x",

--- a/src/impl/metadata/packageBuilder.ts
+++ b/src/impl/metadata/packageBuilder.ts
@@ -167,8 +167,8 @@ export class Packagexml {
 
     for await (const object of describe.metadataObjects) {
       if (
-        this.configs.quickFilters.length !== 0 &&
-        this.configs.quickFilters.includes(object.xmlName)
+        this.configs.excludeFilters.length !== 0 &&
+        this.configs.excludeFilters.includes(object.xmlName)
       ) {
         continue;
       }
@@ -226,8 +226,10 @@ export class Packagexml {
     mdtypes.sort();
     mdtypes.forEach((mdtype) => {
       if (
-        this.configs.quickFilters.length === 0 ||
-        !this.configs.quickFilters.includes(mdtype)
+        (this.configs.excludeFilters.length === 0 ||
+        !this.configs.excludeFilters.includes(mdtype)) &&
+        (this.configs.includeFilters.length === 0 ||
+        this.configs.includeFilters.includes(mdtype))
       ) {
         packageJson.types.push({
           name: mdtype,
@@ -318,8 +320,8 @@ export class Packagexml {
           unfolderedObjectItems.forEach((metadataEntries) => {
             if (metadataEntries) {
               if (
-                this.configs.quickFilters.length !== 0 &&
-                this.configs.quickFilters.includes(
+                this.configs.excludeFilters.length !== 0 &&
+                this.configs.excludeFilters.includes(
                   metadataEntries.type + ":" + metadataEntries.fullName
                 )
               ) {
@@ -391,7 +393,8 @@ export class Packagexml {
 }
 
 export class BuildConfig {
-  public quickFilters: string[];
+  public includeFilters: string[];
+  public excludeFilters: string[];
   public excludeManaged: boolean;
   public includeChilds: boolean;
   public apiVersion: string;
@@ -403,11 +406,29 @@ export class BuildConfig {
     this.excludeManaged = flags["excludemanaged"];
     this.includeChilds = flags["includechilds"];
     this.apiVersion = flags["apiversion"] || apiVersion;
-    this.quickFilters = flags["quickfilter"]
-      ? flags["quickfilter"].split(",").map((elem) => {
+    this.excludeFilters = flags["excludefilter"]
+      ? flags["excludefilter"].split(",").map((elem) => {
           return elem.trim();
         })
       : [];
+    this.excludeFilters = flags["quickfilter"]
+      ? this.excludeFilters.concat(flags["quickfilter"].split(",").map((elem) => {
+          return elem.trim();
+        }))
+      : this.excludeFilters;
+    this.excludeFilters = flags["excludefilter"]
+      ? flags["excludefilter"].split(",").map((elem) => {
+          return elem.trim();
+        })
+      : [];
+    this.includeFilters = flags["includefilter"]
+      ? flags["includefilter"].split(",").map((elem) => {
+          return elem.trim();
+        })
+      : [];
+    if (this.includeFilters.length) {
+      this.excludeFilters = [];
+    }
     this.outputFile = flags["outputfile"] || "package.xml";
   }
 }


### PR DESCRIPTION
Fixes #260 which is closed because it went stale.

`--quickfilter` (`-q`) is deprecated, but aliased to `--excludefilter` to maintain functionality
`--excludefilter` (`-e`) replaces `--quickfilter` and is better named, excludes specified metadata types from the output xml
`--includefilter` (`-i`) complements `--excludefilter`, includes only specified metadata types in the output xml

If both `--includefilter` and `--excludefilter` are specified, then `--excludefilter` is ignored; these flags are logically mutually exclusive.

I'm not sure if `README.md` and/or `oclif.manifest.json` need manual updating as a result of this change or if that's an automated process. Happy to make the updates manually if required.