### PR TITLE
update PMD to version 6.34.0.

### DIFF
--- a/messages/source_pmd.json
+++ b/messages/source_pmd.json
@@ -6,5 +6,5 @@
   "formatFlagDescription": "[default: text] The format for the pmd output, Possible values are available at https://pmd.github.io/latest/pmd_userdocs_cli_reference.html#available-report-formats",
   "reportFlagDescription": "[default: pmd-output] The path to where the output of the analysis should be written",
   "supressoutputFlagDescription": "[default: false] Supress the ouptut of the analysis to be displayed in the console",
-  "versionFlagDescription": "[default: 6.30.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory"
+  "versionFlagDescription": "[default: 6.34.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory"
 }

--- a/resources/pmd-ruleset.xml
+++ b/resources/pmd-ruleset.xml
@@ -63,14 +63,19 @@
             <property name="strictMode" value="true" />
         </properties>
     </rule>
-    <rule ref="category/apex/codestyle.xml/VariableNamingConventions">
+    <rule ref="category/apex/codestyle.xml/FieldNamingConventions">
         <priority>3</priority>
-        <properties>
-            <property name="checkMembers" value="true" />
-            <property name="checkLocals" value="true" />
-            <property name="checkParameters" value="true" />
-        </properties>
     </rule>
+    <rule ref="category/apex/codestyle.xml/FormalParameterNamingConventions">
+        <priority>3</priority>
+    </rule>
+    <rule ref="category/apex/codestyle.xml/LocalVariableNamingConventions">
+        <priority>3</priority>
+    </rule>
+    <rule ref="category/apex/codestyle.xml/PropertyNamingConventions">
+        <priority>3</priority>
+    </rule>
+
     <rule ref="category/apex/codestyle.xml/WhileLoopsMustUseBraces">
         <priority>1</priority>
     </rule>
@@ -122,6 +127,12 @@
     </rule>
 
     <!-- error prone -->
+    <rule ref="category/apex/errorprone.xml/ApexCSRF">
+        <priority>1</priority>
+    </rule>
+    <rule ref="category/apex/errorprone.xml/OverrideBothEqualsAndHashcode">
+        <priority>1</priority>
+    </rule>
     <rule ref="category/apex/errorprone.xml/AvoidDirectAccessTriggerMap">
         <priority>1</priority>
     </rule>
@@ -147,13 +158,7 @@
         <priority>1</priority>
     </rule>
 
-    <rule ref="category/apex/performance.xml/AvoidDmlStatementsInLoops">
-        <priority>2</priority>
-    </rule>
-    <rule ref="category/apex/performance.xml/AvoidSoqlInLoops">
-        <priority>2</priority>
-    </rule>
-    <rule ref="category/apex/performance.xml/AvoidSoslInLoops">
+    <rule ref="category/apex/performance.xml/OperationWithLimitsInLoop">
         <priority>2</priority>
     </rule>
 
@@ -163,7 +168,7 @@
     <rule ref="category/apex/security.xml/ApexCRUDViolation">
         <priority>5</priority>
     </rule>
-    <rule ref="category/apex/security.xml/ApexCSRF">
+    <rule ref="category/vf/security.xml/VfHtmlStyleTagXss">
         <priority>1</priority>
     </rule>
     <rule ref="category/apex/security.xml/ApexDangerousMethods">

--- a/src/commands/sfpowerkit/source/pmd.ts
+++ b/src/commands/sfpowerkit/source/pmd.ts
@@ -60,7 +60,7 @@ export default class Pmd extends SfdxCommand {
     }),
     version: flags.string({
       required: false,
-      default: "6.30.0",
+      default: "6.34.0",
       description: messages.getMessage("versionFlagDescription"),
     }),
     loglevel: flags.enum({


### PR DESCRIPTION
The default PMD version is now 6.34.0.
The deprecated rules have been removed from
`pmd-ruleset.xml` and have been replaced by
the new rules equivalent.