### PR TITLE
Automatically authorize a user fetching an org from a pool

### DIFF
--- a/messages/scratchorg_poolFetch.json
+++ b/messages/scratchorg_poolFetch.json
@@ -4,5 +4,6 @@
   "mypoolDescription": "Filter the tag for any additions created  by the executor of the command",
   "aliasDescription":"Fetch and set an alias for the org",
   "donotopenDescription": "Do not open the scratch org after authenticating while using sfdxAuth url based pools",
+  "setdefaultusernameDescription": "set the authenticated org as the default username that all commands run against",
   "sendToUserDescription": "Send the credentials of the fetched scratchorg to another DevHub user, Useful for situations when pool is only limited to certain users"
 }

--- a/messages/scratchorg_poolFetch.json
+++ b/messages/scratchorg_poolFetch.json
@@ -3,7 +3,6 @@
   "tagDescription": "(required) tag used to identify the scratch org pool",
   "mypoolDescription": "Filter the tag for any additions created  by the executor of the command",
   "aliasDescription":"Fetch and set an alias for the org",
-  "donotopenDescription": "Do not open the scratch org after authenticating while using sfdxAuth url based pools",
   "setdefaultusernameDescription": "set the authenticated org as the default username that all commands run against",
   "sendToUserDescription": "Send the credentials of the fetched scratchorg to another DevHub user, Useful for situations when pool is only limited to certain users"
 }

--- a/messages/scratchorg_poolFetch.json
+++ b/messages/scratchorg_poolFetch.json
@@ -2,5 +2,6 @@
   "commandDescription": "Gets an active/unused scratch org from the scratch org pool",
   "tagDescription": "(required) tag used to identify the scratch org pool",
   "mypoolDescription": "Filter the tag for any additions created  by the executor of the command",
+  "aliasDescription":"Fetch and set an alias for the org",
   "sendToUserDescription": "Send the credentials of the fetched scratchorg to another DevHub user, Useful for situations when pool is only limited to certain users"
 }

--- a/messages/scratchorg_poolFetch.json
+++ b/messages/scratchorg_poolFetch.json
@@ -3,5 +3,6 @@
   "tagDescription": "(required) tag used to identify the scratch org pool",
   "mypoolDescription": "Filter the tag for any additions created  by the executor of the command",
   "aliasDescription":"Fetch and set an alias for the org",
+  "donotopenDescription": "Do not open the scratch org after authenticating while using sfdxAuth url based pools",
   "sendToUserDescription": "Send the credentials of the fetched scratchorg to another DevHub user, Useful for situations when pool is only limited to certain users"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3717,9 +3717,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -6456,9 +6456,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yallist": {
       "version": "2.1.2",

--- a/src/commands/sfpowerkit/pool/fetch.ts
+++ b/src/commands/sfpowerkit/pool/fetch.ts
@@ -41,10 +41,6 @@ export default class Fetch extends SfdxCommand {
       description: messages.getMessage("aliasDescription"),
       required: false,
     }),
-    donotopen: flags.boolean({
-      description: messages.getMessage("donotopenDescription"),
-      required: false,
-    }),
     sendtouser: flags.string({
       char: "s",
       description: messages.getMessage("sendToUserDescription"),
@@ -91,7 +87,6 @@ export default class Fetch extends SfdxCommand {
       this.flags.mypool,
       this.flags.sendtouser,
       this.flags.alias,
-      this.flags.donotopen,
       this.flags.setdefaultusername
     );
 

--- a/src/commands/sfpowerkit/pool/fetch.ts
+++ b/src/commands/sfpowerkit/pool/fetch.ts
@@ -50,6 +50,11 @@ export default class Fetch extends SfdxCommand {
       description: messages.getMessage("sendToUserDescription"),
       required: false,
     }),
+    setdefaultusername: flags.boolean({
+      char: "d",
+      description: messages.getMessage("setdefaultusernameDescription"),
+      required: false,
+    }),
     loglevel: flags.enum({
       description: "logging level for this command invocation",
       default: "info",
@@ -86,7 +91,8 @@ export default class Fetch extends SfdxCommand {
       this.flags.mypool,
       this.flags.sendtouser,
       this.flags.alias,
-      this.flags.donotopen
+      this.flags.donotopen,
+      this.flags.setdefaultusername
     );
 
     let result = await fetchImpl.execute();

--- a/src/commands/sfpowerkit/pool/fetch.ts
+++ b/src/commands/sfpowerkit/pool/fetch.ts
@@ -36,6 +36,11 @@ export default class Fetch extends SfdxCommand {
       description: messages.getMessage("mypoolDescription"),
       required: false,
     }),
+    alias: flags.string({
+      char: "a",
+      description: messages.getMessage("aliasDescription"),
+      required: false,
+    }),
     sendtouser: flags.string({
       char: "s",
       description: messages.getMessage("sendToUserDescription"),
@@ -75,7 +80,8 @@ export default class Fetch extends SfdxCommand {
       this.hubOrg,
       this.flags.tag,
       this.flags.mypool,
-      this.flags.sendtouser
+      this.flags.sendtouser,
+      this.flags.alias
     );
 
     let result = await fetchImpl.execute();
@@ -89,6 +95,8 @@ export default class Fetch extends SfdxCommand {
         }
       }
       this.ux.table(list, ["key", "value"]);
+
+      fetchImpl.loginToScratchOrgIfSfdxAuthURLExits(result);
     }
 
     if (!this.flags.sendtouser) return result as AnyJson;

--- a/src/commands/sfpowerkit/pool/fetch.ts
+++ b/src/commands/sfpowerkit/pool/fetch.ts
@@ -41,6 +41,10 @@ export default class Fetch extends SfdxCommand {
       description: messages.getMessage("aliasDescription"),
       required: false,
     }),
+    donotopen: flags.boolean({
+      description: messages.getMessage("donotopenDescription"),
+      required: false,
+    }),
     sendtouser: flags.string({
       char: "s",
       description: messages.getMessage("sendToUserDescription"),
@@ -81,7 +85,8 @@ export default class Fetch extends SfdxCommand {
       this.flags.tag,
       this.flags.mypool,
       this.flags.sendtouser,
-      this.flags.alias
+      this.flags.alias,
+      this.flags.donotopen
     );
 
     let result = await fetchImpl.execute();

--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -200,6 +200,7 @@ export default class PoolCreateImpl {
                 ? "Available"
                 : "",
               Password__c: scratchOrg.password,
+              SfdxAuthUrl__c: scratchOrg.sfdxAuthUrl,
             },
             this.hubOrg
           );
@@ -672,6 +673,7 @@ export default class PoolCreateImpl {
                 ? "Available"
                 : "",
               Password__c: scratchOrg.password,
+              SfdxAuthUrl__c: scratchOrg.sfdxAuthUrl,
             },
             this.hubOrg
           ).then(

--- a/src/impl/pool/scratchorg/poolFetchImpl.ts
+++ b/src/impl/pool/scratchorg/poolFetchImpl.ts
@@ -149,6 +149,14 @@ export default class PoolFetchImpl {
 
       fs.unlinkSync("soAuth.json");
 
+
+      //Run shape list to reassign this org to the pool
+      child_process.execSync(`sfdx force:org:shape:list`, {
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+
+
       if (!this.isScratchOrgNotTobeOpened) {
         SFPowerkit.log(
           `Opening Scratch org ${soDetail.username}`,

--- a/src/impl/pool/scratchorg/poolFetchImpl.ts
+++ b/src/impl/pool/scratchorg/poolFetchImpl.ts
@@ -9,7 +9,6 @@ export default class PoolFetchImpl {
   private mypool: boolean;
   private sendToUser: string;
   private alias: string;
-  private isScratchOrgNotTobeOpened: boolean;
   private setdefaultusername:boolean;
 
   public constructor(
@@ -18,7 +17,6 @@ export default class PoolFetchImpl {
     mypool: boolean,
     sendToUser: string,
     alias: string,
-    isScratchOrgNotTobeOpened: boolean,
     setdefaultusername:boolean
   ) {
     this.hubOrg = hubOrg;
@@ -26,7 +24,6 @@ export default class PoolFetchImpl {
     this.mypool = mypool;
     this.sendToUser = sendToUser;
     this.alias = alias;
-    this.isScratchOrgNotTobeOpened = isScratchOrgNotTobeOpened;
     this.setdefaultusername = setdefaultusername;
   }
 
@@ -140,7 +137,7 @@ export default class PoolFetchImpl {
       );
 
       let authURLStoreCommand:string = `sfdx auth:sfdxurl:store -f soAuth.json`;
-      
+
       if(this.alias)
          authURLStoreCommand+=` -a ${this.alias}`;
       if(this.setdefaultusername)
@@ -160,17 +157,6 @@ export default class PoolFetchImpl {
         stdio: "pipe",
       });
 
-
-      if (!this.isScratchOrgNotTobeOpened) {
-        SFPowerkit.log(
-          `Opening Scratch org ${soDetail.username}`,
-          LoggerLevel.INFO
-        );
-        child_process.execSync(`sfdx force:org:open -u ${soDetail.username}`, {
-          encoding: "utf8",
-          stdio: "inherit",
-        });
-      }
     }
   }
 }

--- a/src/impl/pool/scratchorg/poolFetchImpl.ts
+++ b/src/impl/pool/scratchorg/poolFetchImpl.ts
@@ -147,6 +147,8 @@ export default class PoolFetchImpl {
           stdio: "inherit",
         });
 
+      fs.unlinkSync("soAuth.json");
+
       if (!this.isScratchOrgNotTobeOpened) {
         SFPowerkit.log(
           `Opening Scratch org ${soDetail.username}`,

--- a/src/impl/pool/scratchorg/poolFetchImpl.ts
+++ b/src/impl/pool/scratchorg/poolFetchImpl.ts
@@ -10,6 +10,7 @@ export default class PoolFetchImpl {
   private sendToUser: string;
   private alias: string;
   private isScratchOrgNotTobeOpened: boolean;
+  private setdefaultusername:boolean;
 
   public constructor(
     hubOrg: Org,
@@ -17,7 +18,8 @@ export default class PoolFetchImpl {
     mypool: boolean,
     sendToUser: string,
     alias: string,
-    isScratchOrgNotTobeOpened: boolean
+    isScratchOrgNotTobeOpened: boolean,
+    setdefaultusername:boolean
   ) {
     this.hubOrg = hubOrg;
     this.tag = tag;
@@ -25,6 +27,7 @@ export default class PoolFetchImpl {
     this.sendToUser = sendToUser;
     this.alias = alias;
     this.isScratchOrgNotTobeOpened = isScratchOrgNotTobeOpened;
+    this.setdefaultusername = setdefaultusername;
   }
 
   public async execute(): Promise<ScratchOrg> {
@@ -136,16 +139,17 @@ export default class PoolFetchImpl {
         LoggerLevel.INFO
       );
 
-      if (this.alias)
-        child_process.execSync(
-          `sfdx auth:sfdxurl:store -f soAuth.json -a ${this.alias}`,
+      let authURLStoreCommand:string = `sfdx auth:sfdxurl:store -f soAuth.json`;
+      
+      if(this.alias)
+         authURLStoreCommand+=` -a ${this.alias}`;
+      if(this.setdefaultusername)
+          authURLStoreCommand+=` --setdefaultusername`;
+
+         child_process.execSync(
+          authURLStoreCommand,
           { encoding: "utf8", stdio: "inherit" }
-        );
-      else
-        child_process.execSync(`sfdx auth:sfdxurl:store -f soAuth.json`, {
-          encoding: "utf8",
-          stdio: "inherit",
-        });
+        );;
 
       fs.unlinkSync("soAuth.json");
 

--- a/src_saleforce_packages/scratchorgpool/force-app/main/default/objects/ScratchOrgInfo/fields/SfdxAuthUrl__c.field-meta.xml
+++ b/src_saleforce_packages/scratchorgpool/force-app/main/default/objects/ScratchOrgInfo/fields/SfdxAuthUrl__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SfdxAuthUrl__c</fullName>
+    <externalId>false</externalId>
+    <label>Sfdx Auth Url</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
This PR goal is to automatically authorize a user running `sfdx sfpowerkit:pool:fetch`, without him having to manually login to the Org.

To do this, we need the Sfdx Auth Url for the Scratch Org.
As Sfdx Auth Url is not returned when the user creating the Scratch Org has login to the DevHub via JWT, this will only be available if the user has login via `sfdx force:auth:sfdxurl:store`. DevHub Auth Url could be saved as a secret in the repo.

This PR has several parts:
* Add a field to store the Sfdx Auth Url on `ScratchOrgInfo` in the `sfpower-scratchorg-pool` Unlocked package
* Update the `sfdx sfpowerkit:pool:create` to save the Sfdx Auth Url if available
* Update the `sfdx sfpowerkit:pool:fetch` to automatically authorize a user if the Sfdx Auth Url is available for the Scratch Org
