### PR TITLE
Skip login to scratch org created with JWT auth

### DIFF
--- a/src/commands/sfpowerkit/pool/fetch.ts
+++ b/src/commands/sfpowerkit/pool/fetch.ts
@@ -102,7 +102,7 @@ export default class Fetch extends SfdxCommand {
       }
       this.ux.table(list, ["key", "value"]);
 
-      fetchImpl.loginToScratchOrgIfSfdxAuthURLExits(result);
+      fetchImpl.loginToScratchOrgIfSfdxAuthURLExists(result);
     }
 
     if (!this.flags.sendtouser) return result as AnyJson;

--- a/src/impl/pool/scratchorg/poolFetchImpl.ts
+++ b/src/impl/pool/scratchorg/poolFetchImpl.ts
@@ -125,8 +125,13 @@ export default class PoolFetchImpl {
     return soDetail;
   }
 
-  public loginToScratchOrgIfSfdxAuthURLExits(soDetail: ScratchOrg) {
+  public loginToScratchOrgIfSfdxAuthURLExists(soDetail: ScratchOrg) {
     if (soDetail.sfdxAuthUrl) {
+
+      if (!this.isValidSfdxAuthUrl(soDetail.sfdxAuthUrl)) {
+        return;
+      }
+
       let soLogin: any = {};
       soLogin.sfdxAuthUrl = soDetail.sfdxAuthUrl;
       fs.writeFileSync("soAuth.json", JSON.stringify(soLogin));
@@ -157,6 +162,25 @@ export default class PoolFetchImpl {
         stdio: "pipe",
       });
 
+    }
+  }
+
+
+  private isValidSfdxAuthUrl(sfdxAuthUrl: string): boolean {
+    if (sfdxAuthUrl.match(/force:\/\/(?<refreshToken>[a-zA-Z0-9._]+)@.+/)) {
+      return true;
+    } else {
+      let match = sfdxAuthUrl.match(/force:\/\/(?<clientId>[a-zA-Z]+):(?<clientSecret>[a-zA-Z0-9]*):(?<refreshToken>[a-zA-Z0-9._]+)@.+/)
+
+      if (match !== null) {
+        if (match.groups.refreshToken === "undefined") {
+          return false;
+        } else {
+          return true;
+        }
+      } else {
+        return false;
+      }
     }
   }
 }


### PR DESCRIPTION
- Skip login to scratch orgs created using a Dev Hub authenticated with JWT, when fetching from scratch org pool 
- AuthInfo.getSfdxAuthUrl() does not return a valid Sfdx Auth URL for a scratch org created using a Dev Hub authenticated using JWT. The refreshToken is undefined and the clientId is incorrect.
- The login attempt is skipped when the Sfdx Auth URL is invalid 