### PR TITLE
Bug: Packages in  mono repo getting installed

### DIFF
--- a/src/commands/sfpowerkit/package/dependencies/install.ts
+++ b/src/commands/sfpowerkit/package/dependencies/install.ts
@@ -152,8 +152,7 @@ export default class Install extends SfdxCommand {
       );
     }
 
-    if (isNullOrUndefined(installedpackages) || installedpackages.length == 0) {
-      this.flags.updateall = true;
+    if (!installedpackages || installedpackages.length == 0) {
       installedpackages = [];
     }
 

--- a/src/commands/sfpowerkit/package/dependencies/install.ts
+++ b/src/commands/sfpowerkit/package/dependencies/install.ts
@@ -7,7 +7,6 @@ import { SfdxProject } from "@salesforce/core";
 import { loadSFDX } from "../../../../sfdxnode/GetNodeWrapper";
 import { sfdx } from "../../../..//sfdxnode/parallel";
 import { SFPowerkit, LoggerLevel } from "../../../../sfpowerkit";
-import { isNullOrUndefined } from "util";
 import { get18DigitSalesforceId } from "./../../../../utils/get18DigitSalesforceId";
 let retry = require("async-retry");
 


### PR DESCRIPTION
Packages in the same repo can be added as a dependency to another package, and it should be skipped as source
code of these packages are available. A bug was causing all the packages to be installed if there was no existing packages in the scratch org