### PR TITLE
Fix for Scratch Orgs Not created with JWT Bearer Flow

### DIFF
--- a/src/utils/scratchOrgUtils.ts
+++ b/src/utils/scratchOrgUtils.ts
@@ -194,9 +194,18 @@ export default class ScratchOrgUtils {
     scratchOrg.password = passwordData.password;
 
     //Get Sfdx Auth URL
+    try
+    {
     const authInfo = await AuthInfo.create({ username: scratchOrg.username });
-
     scratchOrg.sfdxAuthUrl = authInfo.getSfdxAuthUrl();
+    }
+    catch(error)
+    {
+      SFPowerkit.log(
+        `Unable to fetch authURL for ${passwordData.username}. Only Scratch Orgs created from DevHub using authenticated using auth:sfdxurl or auth:web will have access token and enabled for autoLogin`,
+        LoggerLevel.INFO
+      );
+    }
 
 
     if (!passwordData.password) {

--- a/src/utils/scratchOrgUtils.ts
+++ b/src/utils/scratchOrgUtils.ts
@@ -202,7 +202,7 @@ export default class ScratchOrgUtils {
     catch(error)
     {
       SFPowerkit.log(
-        `Unable to fetch authURL for ${passwordData.username}. Only Scratch Orgs created from DevHub using authenticated using auth:sfdxurl or auth:web will have access token and enabled for autoLogin`,
+        `Unable to fetch authURL for ${scratchOrg.username}. Only Scratch Orgs created from DevHub using authenticated using auth:sfdxurl or auth:web will have access token and enabled for autoLogin`,
         LoggerLevel.INFO
       );
     }


### PR DESCRIPTION
Fix #542

Scratch Orgs created from a DevHub using JWT bearer token doesnt have authURL. This was not enforced 
in the previsous version of salesforce-core lib. 

This will allow pools to be created, but will show an info message.﻿
