### PR TITLE
Fix test class identification

### DIFF
--- a/src/impl/parser/listeners/ApexTypeListener.ts
+++ b/src/impl/parser/listeners/ApexTypeListener.ts
@@ -13,7 +13,7 @@ export default class ApexTypeListener implements ApexParserListener {
   };
 
   protected enterAnnotation(ctx: AnnotationContext): void {
-    if (ctx._stop.text.toUpperCase() === "ISTEST") {
+    if (ctx.text.toUpperCase().startsWith("@ISTEST")) {
       this.apexType["testClass"] = true;
     }
   }


### PR DESCRIPTION
Fix identification of test classes with parameters in @istest annotation, by
performing string search on entire context instead of _stop.

Fix #546 