### PR TITLE
Added sfdx authURL authentication to smoke test pipeline

### DIFF
--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -36,11 +36,12 @@ steps:
       script: |
         sfdx plugins:link
 
-  - task: sfpwowerscript-authenticateorg-task@9
-    displayName: "Authenticate  HubOrg using ServiceConnection"
+  - task: sfppowerkit-authenticateorg-task@9
+    displayName: "Authenticate HubOrg using authURL"
     inputs:
-      salesforce_connection: "devhub_ma"
-      alias: HubOrg
+      - script: |
+                    echo $(DEVHUB_SFDX_AUTH_URL) > ./authfile
+                    sfdx auth:sfdxurl:store -f authfile -a HubOrg
 
   - task: CmdLine@2
     displayName: Smoke Test Org Commands

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -36,12 +36,12 @@ steps:
       script: |
         sfdx plugins:link
 
-  - task: CmdLine@2
-    displayName: "Authenticate HubOrg using authURL"
+  - task: DownloadSecureFile@1
+    displayName: "HubOrg authFile"
     inputs:
+      secureFile: authFile.json
       script: |
-        echo $(DEVHUB_SFDX_AUTH_URL) > ./authfile
-        sfdx auth:sfdxurl:store -f authfile -a HubOrg
+        sfdx auth:sfdxurl:store -f authFile.json -a HubOrg
 
   - task: CmdLine@2
     displayName: Smoke Test Org Commands

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -37,12 +37,13 @@ steps:
         sfdx plugins:link
 
   - task: DownloadSecureFile@1
+    displayName: 
     name: hubOrgAuthFile
     inputs:
       secureFile: 'authFile.json'
 
   - script: |
-        sfdx auth:sfdxurl:store -f hubOrgAuthFile -a HubOrg
+        sfdx auth:sfdxurl:store -f $(hubOrgAuthFile.secureFilePath) -a HubOrg
     displayName: 'Authenticate HubOrg'
 
   - task: CmdLine@2

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -39,10 +39,11 @@ steps:
   - task: DownloadSecureFile@1
     displayName: "HubOrg authFile"
     inputs:
-      secureFile: authFile.json
+      secureFile: 'authFile.json'
 
   - task: CmdLine@2
     displayName: "Authenticate to HubOrg"
+    inputs:
       script: |
         sfdx auth:sfdxurl:store -f authFile.json -a HubOrg
 

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -37,12 +37,13 @@ steps:
         sfdx plugins:link
 
   - task: DownloadSecureFile@1
-    displayName: "HubOrg authFile"
+    name: hubOrgAuthFile
     inputs:
       secureFile: 'authFile.json'
 
   - script: |
-        sfdx auth:sfdxurl:store -f authFile.json -a HubOrg
+        sfdx auth:sfdxurl:store -f hubOrgAuthFile -a HubOrg
+    displayName: 'Authenticate HubOrg'
 
   - task: CmdLine@2
     displayName: Smoke Test Org Commands

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -40,6 +40,9 @@ steps:
     displayName: "HubOrg authFile"
     inputs:
       secureFile: authFile.json
+
+  - task: CmdLine@2
+    displayName: "Authenticate to HubOrg"
       script: |
         sfdx auth:sfdxurl:store -f authFile.json -a HubOrg
 

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -37,7 +37,6 @@ steps:
         sfdx plugins:link
 
   - task: DownloadSecureFile@1
-    displayName: 
     name: hubOrgAuthFile
     inputs:
       secureFile: 'authFile.json'

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -36,7 +36,7 @@ steps:
       script: |
         sfdx plugins:link
 
-  - task: sfppowerkit-authenticateorg-task@9
+  - task: CmdLine@2
     displayName: "Authenticate HubOrg using authURL"
     inputs:
       - script: |

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -41,10 +41,7 @@ steps:
     inputs:
       secureFile: 'authFile.json'
 
-  - task: CmdLine@2
-    displayName: "Authenticate to HubOrg"
-    inputs:
-      script: |
+  - script: |
         sfdx auth:sfdxurl:store -f authFile.json -a HubOrg
 
   - task: CmdLine@2

--- a/templates/smoke-test-template.yml
+++ b/templates/smoke-test-template.yml
@@ -39,9 +39,9 @@ steps:
   - task: CmdLine@2
     displayName: "Authenticate HubOrg using authURL"
     inputs:
-      - script: |
-                    echo $(DEVHUB_SFDX_AUTH_URL) > ./authfile
-                    sfdx auth:sfdxurl:store -f authfile -a HubOrg
+      script: |
+        echo $(DEVHUB_SFDX_AUTH_URL) > ./authfile
+        sfdx auth:sfdxurl:store -f authfile -a HubOrg
 
   - task: CmdLine@2
     displayName: Smoke Test Org Commands


### PR DESCRIPTION
Smoke tests have been repeatedly failing when pull requests are raised.  
![Screen Shot 2021-08-16 at 4 33 37 pm](https://user-images.githubusercontent.com/40649970/129521042-48ed5060-2604-4c86-a70b-bbef4afba9a2.png)

I looked into azure devOps to inspect the error and found this.
![Screen Shot 2021-08-16 at 4 33 54 pm](https://user-images.githubusercontent.com/40649970/129521179-74b04aa1-c8c0-4146-a0de-9e0e466e721e.png)

Updated the authentication to AuthURL