### PR TITLE
Fix namespace issue with MatchingRules

### DIFF
--- a/src/commands/sfpowerkit/org/matchingrule/activate.ts
+++ b/src/commands/sfpowerkit/org/matchingrule/activate.ts
@@ -134,6 +134,7 @@ export default class Activate extends SfdxCommand {
       this.ux.log(`Preparing Activation`);
       if (isJsonArray(retrieve_matchingRule.MatchingRules.matchingRules)) {
         retrieve_matchingRule.MatchingRules.matchingRules.forEach(element => {
+          element.fullName = element.fullName.replace(/^([^_]+)__([^_]+)/, '$2');
           element.ruleStatus = "Active";
         });
       } else {

--- a/src/commands/sfpowerkit/org/matchingrule/deactivate.ts
+++ b/src/commands/sfpowerkit/org/matchingrule/deactivate.ts
@@ -132,6 +132,7 @@ export default class Deactivate extends SfdxCommand {
 
       if (isJsonArray(retrieve_matchingRule.MatchingRules.matchingRules)) {
         retrieve_matchingRule.MatchingRules.matchingRules.forEach(element => {
+          element.fullName = element.fullName.replace(/^([^_]+)__([^_]+)/, '$2');
           element.ruleStatus = "Inactive";
         });
       } else {


### PR DESCRIPTION
There is a strange quirk with managed MatchingRules where Salesforce will retrieve the metadata with the namespace, but they must be deployed without the namespace. This should resolve that by removing the namespace from the matching rule.