### PR TITLE
feat(pmd): bump PMD to 6.39.0 and add missing rules

### DIFF
--- a/messages/source_pmd.json
+++ b/messages/source_pmd.json
@@ -8,7 +8,7 @@
   "filelistFlagDescription": "Path to file containing a comma delimited list of files to analyze.",
   "reportFlagDescription": "DEPRECATED: use --reportfile instead.",
   "reportfileFlagDescription": "The path to where the output of the analysis should be written",
-  "versionFlagDescription": "[default: 6.34.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory",
+  "versionFlagDescription": "[default: 6.39.0] The version of the pmd to be utilized for the analysis, this version will be downloaded to sfpowerkit's cache directory",
   "minimumpriorityFlagDescription": "Rule priority threshold; rules with lower priority than configured here won't be used.",
   "shortnamesFlagDescription": "Prints shortened filenames in the report.",
   "showsuppressedFlagDescription": "Causes the suppressed rule violations to be added to the report.",

--- a/resources/pmd-ruleset.xml
+++ b/resources/pmd-ruleset.xml
@@ -37,19 +37,37 @@
     <rule ref="category/apex/bestpractices.xml/AvoidLogicInTrigger">
         <priority>3</priority>
     </rule>
+    <rule ref="category/apex/bestpractices.xml/DebugsShouldUseLoggingLevel">
+        <priority>4</priority>
+    </rule>
+    <rule ref="category/apex/bestpractices.xml/UnusedLocalVariable">
+        <priority>1</priority>
+    </rule>
 
     <!-- codestyle -->
     <rule ref="category/apex/codestyle.xml/ClassNamingConventions">
         <priority>4</priority>
     </rule>
+    <rule ref="category/apex/codestyle.xml/FieldDeclarationsShouldBeAtStart">
+        <priority>4</priority>
+    </rule>
+    <rule ref="category/apex/codestyle.xml/FieldNamingConventions">
+        <priority>3</priority>
+    </rule>
     <rule ref="category/apex/codestyle.xml/ForLoopsMustUseBraces">
         <priority>1</priority>
+    </rule>
+    <rule ref="category/apex/codestyle.xml/FormalParameterNamingConventions">
+        <priority>3</priority>
     </rule>
     <rule ref="category/apex/codestyle.xml/IfElseStmtsMustUseBraces">
         <priority>1</priority>
     </rule>
     <rule ref="category/apex/codestyle.xml/IfStmtsMustUseBraces">
         <priority>1</priority>
+    </rule>
+    <rule ref="category/apex/codestyle.xml/LocalVariableNamingConventions">
+        <priority>3</priority>
     </rule>
     <rule ref="category/apex/codestyle.xml/MethodNamingConventions">
         <priority>2</priority>
@@ -63,19 +81,9 @@
             <property name="strictMode" value="true" />
         </properties>
     </rule>
-    <rule ref="category/apex/codestyle.xml/FieldNamingConventions">
-        <priority>3</priority>
-    </rule>
-    <rule ref="category/apex/codestyle.xml/FormalParameterNamingConventions">
-        <priority>3</priority>
-    </rule>
-    <rule ref="category/apex/codestyle.xml/LocalVariableNamingConventions">
-        <priority>3</priority>
-    </rule>
     <rule ref="category/apex/codestyle.xml/PropertyNamingConventions">
         <priority>3</priority>
     </rule>
-
     <rule ref="category/apex/codestyle.xml/WhileLoopsMustUseBraces">
         <priority>1</priority>
     </rule>
@@ -84,7 +92,14 @@
     <rule ref="category/apex/design.xml/AvoidDeeplyNestedIfStmts">
         <priority>3</priority>
     </rule>
-    <rule ref="category/apex/design.xml/CyclomaticComplexity">
+    <rule ref="category/apex/design.xml/CognitiveComplexity">
+      <priority>4</priority>
+      <properties>
+        <property name="classReportLevel" value="50" />
+        <property name="methodReportLevel" value="15" />
+      </properties>
+    </rule>
+   <rule ref="category/apex/design.xml/CyclomaticComplexity">
         <priority>3</priority>
         <properties>
             <property name="classReportLevel" value="40" />
@@ -124,13 +139,14 @@
     <!-- documentation -->
     <rule ref="category/apex/documentation.xml/ApexDoc">
         <priority>5</priority>
+        <properties>
+          <property name="reportProtected" value="true" />
+          <property name="reportPrivate" value="false" />
+        </properties>
     </rule>
 
     <!-- error prone -->
     <rule ref="category/apex/errorprone.xml/ApexCSRF">
-        <priority>1</priority>
-    </rule>
-    <rule ref="category/apex/errorprone.xml/OverrideBothEqualsAndHashcode">
         <priority>1</priority>
     </rule>
     <rule ref="category/apex/errorprone.xml/AvoidDirectAccessTriggerMap">
@@ -154,22 +170,36 @@
     <rule ref="category/apex/errorprone.xml/EmptyTryOrFinallyBlock">
         <priority>1</priority>
     </rule>
+    <rule ref="category/apex/errorprone.xml/EmptyWhileStmt">
+      <priority>1</priority>
+    </rule>
+    <rule ref="category/apex/errorprone.xml/InaccessibleAuraEnabledGetter">
+        <priority>1</priority>
+    </rule>
     <rule ref="category/apex/errorprone.xml/MethodWithSameNameAsEnclosingClass">
         <priority>1</priority>
     </rule>
+    <rule ref="category/apex/errorprone.xml/OverrideBothEqualsAndHashcode">
+        <priority>1</priority>
+    </rule>
+    <rule ref="category/apex/errorprone.xml/TestMethodsMustBeInTestClasses">
+        <priority>3</priority>
+    </rule>
 
+    <!-- Performance -->
+    <rule ref="category/apex/performance.xml/AvoidDebugStatements">
+        <priority>2</priority>
+    </rule>>
     <rule ref="category/apex/performance.xml/OperationWithLimitsInLoop">
         <priority>2</priority>
     </rule>
 
+    <!-- security -->
     <rule ref="category/apex/security.xml/ApexBadCrypto">
         <priority>1</priority>
     </rule>
     <rule ref="category/apex/security.xml/ApexCRUDViolation">
         <priority>5</priority>
-    </rule>
-    <rule ref="category/vf/security.xml/VfHtmlStyleTagXss">
-        <priority>1</priority>
     </rule>
     <rule ref="category/apex/security.xml/ApexDangerousMethods">
         <priority>3</priority>
@@ -196,4 +226,14 @@
         <priority>1</priority>
     </rule>
 
+    <!-- Visualforce -->
+    <rule ref="category/vf/security.xml/VfCsrf">
+        <priority>1</priority>
+    </rule>
+    <rule ref="category/vf/security.xml/VfHtmlStyleTagXss">
+        <priority>1</priority>
+    </rule>
+    <rule ref="category/vf/security.xml/VfUnescapeEl">
+        <priority>1</priority>
+    </rule>
 </ruleset>

--- a/src/commands/sfpowerkit/source/pmd.ts
+++ b/src/commands/sfpowerkit/source/pmd.ts
@@ -106,7 +106,7 @@ export default class Pmd extends SfdxCommand {
 
     version: flags.string({
       required: false,
-      default: "6.34.0",
+      default: "6.39.0",
       description: messages.getMessage("versionFlagDescription"),
     }),
   };


### PR DESCRIPTION
Updates PMD to 6.39.0 and adds the missing rules to the default
ruleset file.
In the default ruleset file, the rules are now declared in the
same order as in PMD's documentation to simplify future maintenance.
See the doc at https://pmd.github.io/latest/pmd_rules_apex.html