### PR TITLE
refactor(diff): use simple-git directly as opposed to simple-git/promise, as its deprecated

### DIFF
--- a/src/impl/project/diff/diffImpl.ts
+++ b/src/impl/project/diff/diffImpl.ts
@@ -22,7 +22,7 @@ import CustomLabelsDiff from './customLabelsDiff';
 import DiffUtil, { DiffFile, DiffFileStatus } from './diffUtil';
 import { Sfpowerkit, LoggerLevel } from '../../../sfpowerkit';
 import { DXProjectManifestUtils } from '../../../utils/dxProjectManifestUtils';
-import simplegit from 'simple-git/promise';
+import simplegit from 'simple-git';
 import { Messages } from '@salesforce/core';
 
 Messages.importMessagesDirectory(__dirname);


### PR DESCRIPTION
Refactor to use lastest version of simple-git, moving away from promises